### PR TITLE
IGA: governed realm-delete, client-update coalescing, commit-time re-sign + origin-URL governance

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientAdapter.java
@@ -830,6 +830,60 @@ public class IgaClientAdapter extends ClientAdapter {
         captureClientProperty("clientId", clientId);
     }
 
+    // -------------------------------------------------------------------------
+    // Client origin-URL columns: rootUrl, baseUrl, managementUrl (the console
+    // "Root URL" / "Home URL" / "Admin URL"). These feed the signed client
+    // origin set: VendorResource.getAllWebOriginsForClient unions a client's
+    // web-origins with its rootUrl/baseUrl/managementUrl origins and the
+    // redirect-URI origins, and SignIdpSettings emits a per-origin
+    // clientAuth:<clientId><origin> signature. Left ungoverned (previously no
+    // override existed) a Root/Home/Admin-URL change applied directly at SAVE
+    // with no CR and no re-sign, staling the clientAuth:* signatures so the
+    // enclave rejects the client at login ("Signed Settings were not able to be
+    // verified"). Capture each as an UPDATE_CLIENT_PROPERTY CR (same entity,
+    // same clientConfig framing; already in CLIENT_SIGNED_ACTION_TYPES so the
+    // commit tail re-signs) and suppress the direct write. Replay applies the
+    // property via IgaReplayDispatcher.replayUpdateClientProperty.
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void setRootUrl(String rootUrl) {
+        if (!isIgaActive()) {
+            super.setRootUrl(rootUrl);
+            return;
+        }
+        // No-op guard (see setWebOrigins): KC re-applies the current value on
+        // every PUT; suppress the phantom UPDATE_CLIENT_PROPERTY CR when unchanged.
+        if (java.util.Objects.equals(rootUrl, super.getRootUrl())) {
+            return;
+        }
+        captureClientProperty("rootUrl", rootUrl);
+    }
+
+    @Override
+    public void setBaseUrl(String baseUrl) {
+        if (!isIgaActive()) {
+            super.setBaseUrl(baseUrl);
+            return;
+        }
+        if (java.util.Objects.equals(baseUrl, super.getBaseUrl())) {
+            return;
+        }
+        captureClientProperty("baseUrl", baseUrl);
+    }
+
+    @Override
+    public void setManagementUrl(String managementUrl) {
+        if (!isIgaActive()) {
+            super.setManagementUrl(managementUrl);
+            return;
+        }
+        if (java.util.Objects.equals(managementUrl, super.getManagementUrl())) {
+            return;
+        }
+        captureClientProperty("managementUrl", managementUrl);
+    }
+
     /**
      * Capture a single token-shaping client-config property change as an
      * {@code UPDATE_CLIENT_PROPERTY} change request (PROPERTY = the field name,

--- a/iga-core/src/main/java/org/tidecloak/iga/replay/IgaReplayDispatcher.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/replay/IgaReplayDispatcher.java
@@ -2049,6 +2049,13 @@ public class IgaReplayDispatcher {
                 }
                 case "protocol" -> client.setProtocol(value);
                 case "clientId" -> { if (value != null) client.setClientId(value); }
+                // Origin-URL columns (see IgaClientAdapter setRootUrl/setBaseUrl/
+                // setManagementUrl). A null value is a legitimate "field cleared"
+                // and is applied as-is; these feed getAllWebOriginsForClient, so
+                // the commit tail's reSignForClientSettings rebuilds clientAuth:*.
+                case "rootUrl" -> client.setRootUrl(value);
+                case "baseUrl" -> client.setBaseUrl(value);
+                case "managementUrl" -> client.setManagementUrl(value);
                 default -> log.warnf("IGA replay UPDATE_CLIENT_PROPERTY: unknown property '%s' "
                         + "for client %s — ignoring", property, client.getId());
             }

--- a/iga-core/src/main/java/org/tidecloak/iga/signing/IgaIdpSettingsResign.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/signing/IgaIdpSettingsResign.java
@@ -127,8 +127,20 @@ public final class IgaIdpSettingsResign {
      * from current realm state (idempotent), so triggering on the full client-CR
      * family is safe, matches the manual "re-sign settings" button admins run after
      * any client save, and stays correct if the signed draft is ever widened.
+     *
+     * <p>{@code CREATE_CLIENT} and {@code DELETE_CLIENT} are included because the
+     * signed bundle's client-origin list is built from the set of live realm
+     * clients: adding a client introduces a new {@code clientAuth:<clientId><origin>}
+     * signature that must be minted, and removing one leaves the remaining bundle
+     * needing a re-sign (the now-orphan {@code clientAuth:*} keys for the deleted
+     * client are harmless and are not pruned). Their replay runs BEFORE the commit
+     * tail's {@link #reSignForClientSettings}, so at re-sign time a created client
+     * already exists and a deleted client is already gone, so the rebuild
+     * reflects live state.
      */
     static final java.util.Set<String> CLIENT_SIGNED_ACTION_TYPES = java.util.Set.of(
+            "CREATE_CLIENT",
+            "DELETE_CLIENT",
             "SET_CLIENT_ATTRIBUTE",
             "REMOVE_CLIENT_ATTRIBUTE",
             "UPDATE_CLIENT_PROPERTY",

--- a/iga-core/src/test/java/org/tidecloak/iga/replay/ReplayOffboardRealmTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/replay/ReplayOffboardRealmTest.java
@@ -92,6 +92,17 @@ class ReplayOffboardRealmTest {
                 .thenReturn(RagnarokOffboardResult.ok("torn down 3 things"));
         KeycloakSession session = sessionWith(realm, svc);
         EntityManager em = mock(EntityManager.class);
+        // After the SPI teardown, replayOffboardRealm neutralizes the realm's IGA_AUTHORIZER
+        // mode row(s) via em.createNamedQuery("IgaAuthorizer.findByRealm", ...).getResultList()
+        // (so resolveMode falls to the Tideless branch post-offboard). The bare EntityManager
+        // mock returns null for createNamedQuery → NPE; stub it to yield an empty result list.
+        @SuppressWarnings("unchecked")
+        jakarta.persistence.TypedQuery<org.tidecloak.iga.entities.IgaAuthorizerEntity> authQ =
+                mock(jakarta.persistence.TypedQuery.class);
+        when(em.createNamedQuery(eq("IgaAuthorizer.findByRealm"),
+                eq(org.tidecloak.iga.entities.IgaAuthorizerEntity.class))).thenReturn(authQ);
+        when(authQ.setParameter(org.mockito.ArgumentMatchers.anyString(), any())).thenReturn(authQ);
+        when(authQ.getResultList()).thenReturn(java.util.Collections.emptyList());
 
         assertDoesNotThrow(() -> {
             try {

--- a/iga-core/src/test/java/org/tidecloak/iga/rest/IgaBulkCommitOrderTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/rest/IgaBulkCommitOrderTest.java
@@ -71,6 +71,12 @@ class IgaBulkCommitOrderTest {
         when(realm.getId()).thenReturn(REALM_ID);
         when(session.getProvider(JpaConnectionProvider.class)).thenReturn(jpa);
         when(jpa.getEntityManager()).thenReturn(em);
+        // bulkAuthorize's post-batch convergeAfterCommit block re-resolves the LIVE realm via
+        // session.realms().getRealm(realmId) (added with the DELETE_REALM guard) and only runs
+        // converge when it is non-null. These tests pin the sort/loop ORDERING, not converge, so
+        // return a RealmProvider whose getRealm(...) is null → the converge block is skipped.
+        org.keycloak.models.RealmProvider realmProvider = mock(org.keycloak.models.RealmProvider.class);
+        when(session.realms()).thenReturn(realmProvider);
         resource = new IgaAdminResource(session, realm, auth);
     }
 

--- a/iga-core/src/test/java/org/tidecloak/iga/rest/IgaCommitDependencyGateTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/rest/IgaCommitDependencyGateTest.java
@@ -68,6 +68,12 @@ class IgaCommitDependencyGateTest {
         when(realm.getId()).thenReturn(REALM_ID);
         when(session.getProvider(JpaConnectionProvider.class)).thenReturn(jpa);
         when(jpa.getEntityManager()).thenReturn(em);
+        // The bulk path's post-batch convergeAfterCommit block re-resolves the LIVE realm via
+        // session.realms().getRealm(realmId) and only runs converge when non-null. This test
+        // pins the dependency gate, not converge, so return a RealmProvider whose getRealm(...)
+        // is null → the converge block is skipped (avoids an unrelated NPE on the bare mock).
+        org.keycloak.models.RealmProvider realmProvider = mock(org.keycloak.models.RealmProvider.class);
+        when(session.realms()).thenReturn(realmProvider);
         // requireManageRealm() is a void no-op on the mock (permission granted).
         resource = new IgaAdminResource(session, realm, auth);
 

--- a/iga-core/src/test/java/org/tidecloak/iga/rest/IgaMultiAdminLegacyLaneRefusalTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/rest/IgaMultiAdminLegacyLaneRefusalTest.java
@@ -100,6 +100,23 @@ class IgaMultiAdminLegacyLaneRefusalTest {
         row.setMode(TideAttestor.MODE_MULTI_ADMIN);
         stubAuthorizerFindByRealm(row);
         stubEmptyAuthorizations();
+        stubNoTideRealmAdminPolicy();
+    }
+
+    /**
+     * The commit lane's sub-quorum guard resolves the multiAdmin threshold via
+     * {@code TideAttestor.getThreshold -> findTideRealmAdminPolicy}, which queries
+     * {@code IgaRolePolicy.findByRealmAndName}. With no policy row the threshold falls back to
+     * {@code max(1, floor(0.7 * activeAdmins))} = 1 (the bare realm mock has no admins), so a
+     * commit with 0 collected approvals is refused sub-quorum. Stub the query to no rows.
+     */
+    @SuppressWarnings("unchecked")
+    private void stubNoTideRealmAdminPolicy() {
+        TypedQuery<org.tidecloak.iga.entities.IgaRolePolicyEntity> q = mock(TypedQuery.class);
+        lenient().when(em.createNamedQuery(eq("IgaRolePolicy.findByRealmAndName"),
+                eq(org.tidecloak.iga.entities.IgaRolePolicyEntity.class))).thenReturn(q);
+        lenient().when(q.setParameter(anyString(), any())).thenReturn(q);
+        lenient().when(q.getResultStream()).thenAnswer(inv -> Stream.empty());
     }
 
     /** A firstAdmin tide realm: iga.attestor=tide, authorizer row mode=firstAdmin. */
@@ -132,8 +149,12 @@ class IgaMultiAdminLegacyLaneRefusalTest {
         lenient().when(em.createNamedQuery(eq("IgaAuthorizer.findByRealm"), eq(IgaAuthorizerEntity.class)))
                 .thenReturn(q);
         lenient().when(q.setParameter(anyString(), any())).thenReturn(q);
+        // A single commit() call resolves the mode more than once (isMultiAdminMode, then
+        // getThreshold -> resolveMode), each consuming this stream. A single Stream.of(row)
+        // is closed after the first findFirst -> "stream has already been operated upon".
+        // Return a FRESH stream per invocation so every resolveMode read succeeds.
         lenient().when(q.getResultStream())
-                .thenReturn(row == null ? Stream.empty() : Stream.of(row));
+                .thenAnswer(inv -> row == null ? Stream.empty() : Stream.of(row));
     }
 
     @SuppressWarnings("unchecked")
@@ -183,23 +204,33 @@ class IgaMultiAdminLegacyLaneRefusalTest {
 
         Response resp = resource.commit("cr-delete-user");
 
-        assertEquals(409, resp.getStatus(),
-                "a multiAdmin CR on the legacy commit lane must be refused with 409 BEFORE replay");
+        // Two-button model (2026-06-16): approve (/approve, collects dokens) and commit
+        // (/commit, apply-only) are now separate. The legacy commit lane no longer refuses
+        // multiAdmin OUTRIGHT with 409 MULTIADMIN_REQUIRES_APPROVAL_ENCLAVE; instead
+        // refuseSubQuorumCommitForMultiAdmin refuses a commit with < threshold collected
+        // approvals as 412 QUORUM_NOT_MET (BEFORE replay). With 0 approvals and threshold 1
+        // the lone-admin bypass is still refused — the security property is preserved.
+        assertEquals(412, resp.getStatus(),
+                "a multiAdmin CR committed sub-quorum must be refused with 412 BEFORE replay");
         Map<String, Object> body = (Map<String, Object>) resp.getEntity();
-        assertEquals("MULTIADMIN_REQUIRES_APPROVAL_ENCLAVE", body.get("error"));
+        assertEquals("QUORUM_NOT_MET", body.get("error"));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void commit_multiAdmin_producerCr_isAlsoRefused() {
-        // Even a producer-envelope action (GRANT_ROLES) cannot use the simple lane in
-        // multiAdmin — the quorum/doken obligation is identical.
+        // Even a producer-envelope action (GRANT_ROLES) cannot commit sub-quorum in
+        // multiAdmin — the quorum/doken obligation is identical. Same two-button 412
+        // QUORUM_NOT_MET refusal as the non-producer case above.
         asMultiAdminTideRealm();
         IgaChangeRequestEntity cr = pendingCr("cr-grant", "GRANT_ROLES");
         when(em.find(IgaChangeRequestEntity.class, "cr-grant")).thenReturn(cr);
 
         Response resp = resource.commit("cr-grant");
 
-        assertEquals(409, resp.getStatus());
+        assertEquals(412, resp.getStatus());
+        Map<String, Object> body = (Map<String, Object>) resp.getEntity();
+        assertEquals("QUORUM_NOT_MET", body.get("error"));
     }
 
     // -- Scope: firstAdmin / Tideless / ADOPT keep the legacy lane --------------

--- a/iga-core/src/test/java/org/tidecloak/iga/services/IgaFirstAdminAutoCommitTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/services/IgaFirstAdminAutoCommitTest.java
@@ -159,14 +159,16 @@ class IgaFirstAdminAutoCommitTest {
     }
 
     @Test
-    void adopt_manuallyAddedEntity_isNotAutoCommittable() {
+    void adopt_manuallyAddedEntity_isAlsoAutoCommittable_firstAdminRelaxation() {
         KeycloakSession session = mock(KeycloakSession.class);
         RealmModel realm = defaultRoleRealm();
-        // An ADOPT CR for an admin-authored (non-system) entity carries NO
-        // ATTESTATION_ONLY marker (it writes a quarantine sidecar instead) → manual.
+        // firstAdmin relaxation (sign-at-toggle, 2026-06-24): under firstAdmin ALL ADOPT_* CRs
+        // auto-commit — admin-authored/non-system entities included, NOT only the ATTESTATION_ONLY
+        // system ones. The whole ADOPT closure is the firstAdmin's initial attested baseline; the
+        // marker now only drives the quarantine sidecar, not auto-commit eligibility. (Was: false.)
         IgaChangeRequestEntity cr = adoptCr("ADOPT_CLIENT", false);
-        assertFalse(IgaFirstAdminAutoCommit.isAutoCommittable(session, realm, cr),
-                "an ADOPT CR targeting a manually-added (non-system) entity must NOT auto-commit");
+        assertTrue(IgaFirstAdminAutoCommit.isAutoCommittable(session, realm, cr),
+                "under the firstAdmin relaxation every ADOPT_* CR (system + admin-authored) auto-commits");
     }
 
     @Test
@@ -176,9 +178,11 @@ class IgaFirstAdminAutoCommitTest {
         assertTrue(IgaFirstAdminAutoCommit.isAutoCommittable(session, realm,
                         adoptCr("ADOPT_PROTOCOL_MAPPER", true)),
                 "system edge ADOPT (attestation-only) → auto");
-        assertFalse(IgaFirstAdminAutoCommit.isAutoCommittable(session, realm,
+        // firstAdmin relaxation (2026-06-24): a manually-added ADOPT is now ALSO auto (was: manual).
+        // The ATTESTATION_ONLY marker no longer gates ADOPT auto-commit under firstAdmin.
+        assertTrue(IgaFirstAdminAutoCommit.isAutoCommittable(session, realm,
                         adoptCr("ADOPT_PROTOCOL_MAPPER", false)),
-                "manually-added edge ADOPT (no marker) → manual");
+                "manually-added edge ADOPT under firstAdmin → also auto (whole ADOPT closure signs)");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -361,7 +365,7 @@ class IgaFirstAdminAutoCommitTest {
     }
 
     @Test
-    void sweep_manuallyAddedAndNonSystemAdopt_stayPending() {
+    void sweep_manuallyAddedStayPending_butAllAdoptSweep() {
         KeycloakSession session = mock(KeycloakSession.class);
         RealmModel realm = defaultRoleRealm();
         UserModel admin = mock(UserModel.class);
@@ -375,7 +379,10 @@ class IgaFirstAdminAutoCommitTest {
         pending.add(simpleCr("c5", "CREATE_CLIENT_SCOPE"));           // admin-authored scope → manual
         pending.add(simpleCr("c6", "CREATE_GROUP"));                  // admin-authored group → manual
         pending.add(simpleCr("c7", "ADD_PROTOCOL_MAPPER"));          // admin-authored mapper → manual
-        pending.add(adoptCr("adopt-manual", "ADOPT_CLIENT", false));  // admin-authored adopt → manual
+        // firstAdmin relaxation (2026-06-24): an admin-authored (non-ATTESTATION_ONLY) ADOPT
+        // now ALSO auto-commits under firstAdmin — the whole ADOPT closure is the initial
+        // attested baseline. It IS swept; only the non-ADOPT CREATE_* CRs stay manual.
+        pending.add(adoptCr("adopt-manual", "ADOPT_CLIENT", false));  // admin-authored adopt → AUTO
 
         AtomicReference<List<String>> seen = new AtomicReference<>();
         IgaFirstAdminAutoCommit.BulkEngine engine = crIdIn -> {
@@ -393,15 +400,17 @@ class IgaFirstAdminAutoCommitTest {
                     IgaFirstAdminAutoCommit.sweep(session, realm, admin, pending, engine);
 
             assertTrue(result.ran);
-            assertEquals(2, result.eligible,
-                    "only the realm-attribute CR + the SYSTEM ADOPT CR are eligible");
+            assertEquals(3, result.eligible,
+                    "the realm-attribute CR + BOTH ADOPT CRs (system + admin-authored) are eligible "
+                            + "under the firstAdmin ADOPT relaxation (was 2 before 2026-06-24)");
             List<String> requested = seen.get();
             assertTrue(requested.contains("c1"));
             assertTrue(requested.contains("adopt-sys"),
                     "the SYSTEM adopt CR IS swept (its target is a stock-default entity)");
-            // The non-system adopt + every manually-added entity CR must never be requested.
-            assertFalse(requested.contains("adopt-manual"),
-                    "the non-system (admin-authored) ADOPT CR must stay manual");
+            // firstAdmin relaxation (2026-06-24): the admin-authored ADOPT is now ALSO swept.
+            assertTrue(requested.contains("adopt-manual"),
+                    "the admin-authored ADOPT CR is also swept under the firstAdmin relaxation");
+            // Every non-ADOPT manually-added entity CR must still never be requested.
             assertFalse(requested.contains("c3"));
             assertFalse(requested.contains("c4"));
             assertFalse(requested.contains("c5"));

--- a/iga-core/src/test/java/org/tidecloak/iga/services/IgaFullClosureCoverageTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/services/IgaFullClosureCoverageTest.java
@@ -244,7 +244,12 @@ class IgaFullClosureCoverageTest {
 
         assertFalse(result.ran,
                 "a non-capable (no-vendor-key) realm must NOT run the full-closure stamp");
-        assertEquals("not_first_admin_or_not_capable", result.skipReason);
+        // convergeAfterCommit now gates on PROVISIONED (in-memory tide-vendor-key + activeVrk),
+        // NOT can-sign-now/"capable" (a provisioned realm with ORKs down still ENTERS and fails
+        // loud at PHASE-2 sign). The no-vendor-key test realm is not provisioned, so the skip
+        // reason is "not_first_admin_or_not_provisioned"; the old "..._not_capable" literal is
+        // stale. Behavior (ran=false, unitsSigned=0) is unchanged — only the reason string moved.
+        assertEquals("not_first_admin_or_not_provisioned", result.skipReason);
         assertEquals(0, result.unitsSigned, "a gated-out convergence signs zero units");
     }
 }

--- a/iga-core/src/test/java/org/tidecloak/iga/signing/IgaIdpSettingsResignTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/signing/IgaIdpSettingsResignTest.java
@@ -144,6 +144,7 @@ class IgaIdpSettingsResignTest {
 
     @org.junit.jupiter.params.ParameterizedTest
     @org.junit.jupiter.params.provider.ValueSource(strings = {
+            "CREATE_CLIENT", "DELETE_CLIENT",
             "SET_CLIENT_ATTRIBUTE", "REMOVE_CLIENT_ATTRIBUTE", "UPDATE_CLIENT_PROPERTY",
             "UPDATE_CLIENT_WEB_ORIGINS", "UPDATE_CLIENT_REDIRECT_URIS", "ADD_PROTOCOL_MAPPER",
             "UPDATE_PROTOCOL_MAPPER", "REMOVE_PROTOCOL_MAPPER", "SCOPE_MAPPING_ADD",
@@ -151,17 +152,21 @@ class IgaIdpSettingsResignTest {
     void clientPredicateTrueForEveryCapturedClientActionType(String actionType) {
         // Rows are irrelevant to the client predicate (it is action-type only); the
         // re-sign rebuilds the client-origin list wholesale from realm state.
+        // CREATE_CLIENT / DELETE_CLIENT are included: the signed bundle's
+        // client-origin list is built from the set of live realm clients, so
+        // adding or removing a client requires a re-sign (their replay runs
+        // before the commit tail, so live state is already updated at re-sign).
         assertTrue(IgaIdpSettingsResign.changesClientSignedSetting(cr(actionType, "[]")));
     }
 
     @Test
     void clientPredicateFalseForNonClientActions() {
         // RegOn realm-config is handled by the separate maybeReSign path, not the
-        // client re-sign; CREATE_CLIENT is intentionally NOT in the captured set.
+        // client re-sign.
         assertFalse(IgaIdpSettingsResign.changesClientSignedSetting(
                 cr("SET_REALM_CONFIG", "[{\"key\":\"setRegistrationAllowed\",\"value\":\"true\"}]")));
-        assertFalse(IgaIdpSettingsResign.changesClientSignedSetting(cr("CREATE_CLIENT", "[]")));
         assertFalse(IgaIdpSettingsResign.changesClientSignedSetting(cr("GRANT_ROLES", "[]")));
+        assertFalse(IgaIdpSettingsResign.changesClientSignedSetting(cr("CREATE_USER", "[]")));
         assertFalse(IgaIdpSettingsResign.changesClientSignedSetting(null));
     }
 


### PR DESCRIPTION
This branch bundles this session's IGA governance fixes (all on `iga-staging-bugs`):

- **Govern DELETE_REALM** as a first-class change request at the ordinary admin quorum (not offboard's floor).
- **Client-update self-409 loop fix**: a whole-object client PUT decomposes into many setter calls; `IgaClientAdapter` now coalesces them into per-action CRs via `coalesceOrCreate` (mirroring `IgaRealmAdapter`) instead of self-409ing on the 2nd field.
- **Auto re-sign IdP settings on client-settings CR commit** (reuses the `IdpSettingsSigner` SPI; both commit lanes; once-per-batch; fail-closed).
- **Govern client origin-URL changes** (rootUrl/baseUrl/managementUrl captured as `UPDATE_CLIENT_PROPERTY` CRs + replay) and **re-sign on CREATE_CLIENT/DELETE_CLIENT**.
- **Test-harness repair**: fixed 12 pre-existing failing tests (missing mock stubs for the DELETE_REALM-guard `session.realms()` / offboard `createNamedQuery` calls; a reused mocked `Stream`; and stale assertions encoding pre-2026-06 behavior: the firstAdmin ADOPT relaxation, the provisioned-vs-capable converge gate, and the two-button approve/commit 412 semantics). No product code changed for these; no real bugs found.

Full `iga-core` suite now green: **369 tests, 0 failures, 0 errors** (builds clean without `-DskipTests`).