### PR TITLE
iga-core: govern CREATE_CLIENT's full owned unit family in both signing lanes

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/attestors/TideAttestor.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/attestors/TideAttestor.java
@@ -3979,7 +3979,27 @@ public class TideAttestor implements IgaAttestor {
                  "UPDATE_CLIENT_REDIRECT_URIS", "UPDATE_CLIENT_PROPERTY" -> {
                 ClientModel c = resolveClientForStamp(realm, cr);
                 if (c != null) {
-                    units.add(RealmAttestationExporter.clientConfig(session, c, realmId));
+                    if ("CREATE_CLIENT".equals(action)) {
+                        // COMPLETE BY CONSTRUCTION (mirrors the CREATE_USER branch below): a
+                        // freshly-created client's LOGIN replay reads its WHOLE client-owned
+                        // family, not just the client_config node. KC attaches the realm
+                        // default/optional scopes during client creation and any rep-carried
+                        // protocol mappers are FOLDED into this CR (isOnClientCreationPath),
+                        // so NO separate ASSIGN_SCOPE / ADD_PROTOCOL_MAPPER CR is ever filed
+                        // for them. This CR is therefore the ONLY signer of
+                        // client_scope_assignment_set, client_mapper_set,
+                        // scope_role_allowlist_set and each folded protocol_mapper unit.
+                        // Framing only client_config left those columns NULL forever on
+                        // multiAdmin realms (no convergeAfterCommit backstop) and the first
+                        // login to the client fail-closed in replayOrFailClosed.
+                        units.addAll(clientOwnedUnits(session, c, realmId,
+                                /* includeOwnedMappers */ true));
+                    } else {
+                        // SET_* / UPDATE_*: only the client_config node changed. The derived
+                        // owner-sets are already real (signed at create / their own CRs);
+                        // re-framing them would needlessly re-sign already-attested units.
+                        units.add(RealmAttestationExporter.clientConfig(session, c, realmId));
+                    }
                     // Part C: post-flip the multiAdmin carrier is the ONLY signer of the SA user's
                     // user_identity, so frame its per-user units alongside the clientConfig node.
                     // Mirrors the CREATE_ORGANIZATION backing-group precedent below. perUserUnits
@@ -4160,6 +4180,56 @@ public class TideAttestor implements IgaAttestor {
                 RealmAttestationExporter.groupRoleMappingSet(em, groupId, realm.getId());
         if (!roles.roleIds().isEmpty()) {
             units.add(roles);
+        }
+        return units;
+    }
+
+    /**
+     * The FULL producer unit family a client OWNS, built from the (post-change) live model
+     * via the SAME {@link RealmAttestationExporter} builders the login export uses:
+     * {@code client_config} (1, first), {@code client_scope_assignment_set} (11),
+     * {@code client_mapper_set} (12) and {@code scope_role_allowlist_set}/client (14),
+     * plus, when {@code includeOwnedMappers}, one {@code protocol_mapper} (3) per
+     * JWT-relevant mapper the client owns (the {@code jwtRelevantMapperIds} filter + sort,
+     * exactly the login's emission set).
+     *
+     * <p>SINGLE source of truth for "what does a client own", shared by:
+     * <ul>
+     *   <li>{@code enumerateLiveCrUnits}' CREATE_CLIENT framing (multiAdmin lane, with
+     *       mappers: the create rep's mappers are FOLDED into the CR, so no separate
+     *       ADD_PROTOCOL_MAPPER CR ever signs them);</li>
+     *   <li>{@code stampCreateClientUnitFamily} (firstAdmin lane, with mappers);</li>
+     *   <li>{@code stampAdoptClient} (WITHOUT mappers: pre-existing mappers get their own
+     *       ADOPT_PROTOCOL_MAPPER edge CRs, which stamp the per-mapper column).</li>
+     * </ul>
+     * so the two commit lanes and the ADOPT lane cannot drift on the client family list.
+     *
+     * <p>The three set units are emitted even when EMPTY: their columns live on the
+     * always-present ClientEntity row (UnitColumnMapping 11/12/14), so an empty-set stamp
+     * never dangles (unlike the row-carried user/group set units), and the login emits the
+     * assignment/allowlist sets unconditionally.
+     */
+    private static List<AttestationUnit> clientOwnedUnits(KeycloakSession session, ClientModel client,
+                                                          String realmId, boolean includeOwnedMappers) {
+        List<AttestationUnit> units = new ArrayList<>();
+        units.add(RealmAttestationExporter.clientConfig(session, client, realmId));
+        units.add(RealmAttestationExporter.clientScopeAssignmentSet(client, realmId));
+        units.add(RealmAttestationExporter.clientMapperSet(client, realmId));
+        units.add(RealmAttestationExporter.scopeRoleAllowlistSet(
+                ParentType.client, client.getId(), client, realmId));
+        if (includeOwnedMappers) {
+            // jwtRelevantMapperIds applies the login's JWT_BODY_IRRELEVANT_FACTORIES filter
+            // AND sorts ascending, so the per-mapper unit order is deterministic across the
+            // phase-1 scratch framing and the commit-time distribution (mapper ids are pinned
+            // in the CR's REP_JSON, so both replays materialize identical mapper rows).
+            for (String mapperId : RealmAttestationExporter.jwtRelevantMapperIds(
+                    client.getProtocolMappersStream())) {
+                org.keycloak.models.ProtocolMapperModel pm = client.getProtocolMapperById(mapperId);
+                if (pm != null) {
+                    units.add(RealmAttestationExporter.protocolMapperUnit(
+                            pm, ParentType.client, client.getId(), realmId));
+                }
+            }
         }
         return units;
     }
@@ -4400,7 +4470,20 @@ public class TideAttestor implements IgaAttestor {
         try {
             switch (action) {
                 // ---- NODE units: re-stamp the owner's node column with the real envelope ----
-                case "CREATE_CLIENT", "SET_CLIENT_ATTRIBUTE", "UPDATE_CLIENT_WEB_ORIGINS",
+                // CREATE_CLIENT stamps the client's FULL owned unit family (config + the three
+                // derived owner-sets + each folded protocol_mapper), NOT just the node: the
+                // default-scope attachments and any rep-carried mappers are FOLDED into this CR
+                // (isOnClientCreationPath), so no ASSIGN_SCOPE / ADD_PROTOCOL_MAPPER CR ever
+                // signs them and this commit is their ONLY signer. Same family the multiAdmin
+                // lane frames (enumerateLiveCrUnits) via the shared clientOwnedUnits enumerator.
+                case "CREATE_CLIENT" -> {
+                        stampCreateClientUnitFamily(session, realm, mode, em, cr);
+                        // Part B3: also stamp the SA user's user_identity when the client has
+                        // serviceAccountsEnabled. Self-gates (no-op for non-SA clients), so safe
+                        // to call unconditionally for every client CR.
+                        stampServiceAccountUserIfPresent(session, realm, mode, em, cr);
+                }
+                case "SET_CLIENT_ATTRIBUTE", "UPDATE_CLIENT_WEB_ORIGINS",
                      "UPDATE_CLIENT_REDIRECT_URIS", "UPDATE_CLIENT_PROPERTY" -> {
                         stampClientConfig(session, realm, mode, em, cr);
                         // Part B3: also stamp the SA user's user_identity when the client has
@@ -4572,6 +4655,29 @@ public class TideAttestor implements IgaAttestor {
     }
 
     /**
+     * BATCH form of {@link #signProducerEnvelope}: the identical mode dispatch, but a
+     * real-signing-capable firstAdmin realm signs the WHOLE batch in one (chunked)
+     * VVK ceremony round-trip via {@link #signEnvelopesWithFirstAdminVvk} instead of one
+     * ceremony per envelope. {@code out[i]} is byte-identical to what
+     * {@code signProducerEnvelope(session, realm, mode, envelopes[i])} would return
+     * (same real sig bytes for the same envelope on the real path, same deterministic
+     * stub on the stub path), so callers may batch freely. Fail-closed like the single
+     * form: a real ceremony failure propagates.
+     */
+    String[] signProducerEnvelopes(KeycloakSession session, RealmModel realm, String mode,
+                                   byte[][] envelopes) {
+        if (MODE_FIRST_ADMIN.equals(mode) && isRealSigningCapable(realm)) {
+            return signEnvelopesWithFirstAdminVvk(realm, envelopes);
+        }
+        String prefix = MODE_FIRST_ADMIN.equals(mode) ? FIRSTADMIN_SIG_PREFIX : DUMMY_SIG_PREFIX;
+        String[] out = new String[envelopes.length];
+        for (int i = 0; i < envelopes.length; i++) {
+            out[i] = stubSign(prefix, envelopes[i]);
+        }
+        return out;
+    }
+
+    /**
      * Real single-unit firstAdmin VVK ceremony over an arbitrary producer envelope,
      * reusing {@link #signUnitsWithFirstAdminVvk} (the batch signer). Fail-closed.
      *
@@ -4660,6 +4766,34 @@ public class TideAttestor implements IgaAttestor {
             String sig = signProducerEnvelope(session, realm, mode, env);
             em.createQuery("UPDATE ClientEntity e SET e.attestation = :sig WHERE e.id = :id")
                     .setParameter("sig", sig).setParameter("id", client.getId()).executeUpdate();
+        } catch (RuntimeException fatal) { rethrowIfFailClosed(fatal); }
+    }
+
+    /**
+     * firstAdmin-lane CREATE_CLIENT stamp: sign + stamp the client's FULL owned unit
+     * family (the shared {@link #clientOwnedUnits} enumeration, WITH the folded per-mapper
+     * units) instead of only the {@code client_config} node. Envelopes are the SAME
+     * {@link RealmAttestationExporter} builder bytes the login read replays; the batch is
+     * signed in ONE VVK ceremony round-trip via {@link #signProducerEnvelopes} (per-unit
+     * byte-identical to a {@link #signProducerEnvelope} call), and each sig is stamped
+     * through {@link UnitColumnMapping} exactly like the multiAdmin distribution and the
+     * ADOPT stampers. Same fail-closed wrapping as the other stampers.
+     */
+    private void stampCreateClientUnitFamily(KeycloakSession session, RealmModel realm, String mode,
+                                             EntityManager em, IgaChangeRequestEntity cr) {
+        try {
+            ClientModel client = resolveClientForStamp(realm, cr);
+            if (client == null) return;
+            List<AttestationUnit> units = clientOwnedUnits(session, client, realm.getId(),
+                    /* includeOwnedMappers */ true);
+            byte[][] envelopes = new byte[units.size()][];
+            for (int i = 0; i < units.size(); i++) {
+                envelopes[i] = units.get(i).serialize();
+            }
+            String[] sigs = signProducerEnvelopes(session, realm, mode, envelopes);
+            for (int i = 0; i < units.size(); i++) {
+                UnitColumnMapping.stamp(em, units.get(i), sigs[i]);
+            }
         } catch (RuntimeException fatal) { rethrowIfFailClosed(fatal); }
     }
 
@@ -4975,16 +5109,14 @@ public class TideAttestor implements IgaAttestor {
             ClientModel client = realm.getClientById(clientUuid);
             if (client == null) return;
             // client_config (1), client_scope_assignment_set (11), client_mapper_set (12),
-            // scope_role_allowlist_set/client (14).
-            signAndStampUnit(session, realm, mode, em,
-                    RealmAttestationExporter.clientConfig(session, client, realm.getId()));
-            signAndStampUnit(session, realm, mode, em,
-                    RealmAttestationExporter.clientScopeAssignmentSet(client, realm.getId()));
-            signAndStampUnit(session, realm, mode, em,
-                    RealmAttestationExporter.clientMapperSet(client, realm.getId()));
-            signAndStampUnit(session, realm, mode, em,
-                    RealmAttestationExporter.scopeRoleAllowlistSet(
-                            ParentType.client, client.getId(), client, realm.getId()));
+            // scope_role_allowlist_set/client (14): the shared clientOwnedUnits family,
+            // WITHOUT the per-mapper units: a pre-existing client's mappers get their own
+            // ADOPT_PROTOCOL_MAPPER edge CRs (see stampAdoptProtocolMapper), unlike the
+            // folded mappers of a governed CREATE_CLIENT.
+            for (AttestationUnit unit : clientOwnedUnits(session, client, realm.getId(),
+                    /* includeOwnedMappers */ false)) {
+                signAndStampUnit(session, realm, mode, em, unit);
+            }
         } catch (RuntimeException fatal) { rethrowIfFailClosed(fatal); }
     }
 

--- a/iga-core/src/test/java/org/tidecloak/iga/attestors/TideAttestorBuildAllCrUnitsTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/attestors/TideAttestorBuildAllCrUnitsTest.java
@@ -147,6 +147,97 @@ class TideAttestorBuildAllCrUnitsTest {
     }
 
     @Test
+    void createClientCr_enumeratesTheFullClientOwnedFamily_withFoldedMappers_byteIdentical() {
+        // Regression guard for the CREATE_CLIENT multiAdmin coverage bug: the carrier
+        // historically framed ONLY the client_config node (+ SA user units). But KC attaches
+        // the realm default/optional scopes during client creation and any rep-carried
+        // protocol mappers are FOLDED into the CREATE_CLIENT CR (isOnClientCreationPath), so
+        // no separate ASSIGN_SCOPE / ADD_PROTOCOL_MAPPER CR ever signs them. The first login
+        // to the new client emits client_scope_assignment_set / client_mapper_set /
+        // scope_role_allowlist_set (and a protocol_mapper per folded mapper) and fail-closed
+        // on their NULL columns in replayOrFailClosed. On firstAdmin realms convergeAfterCommit
+        // self-healed the NULLs; multiAdmin realms kept them forever.
+        //
+        // The fix: the CREATE_CLIENT branch of enumerateLiveCrUnits frames the client's FULL
+        // owned unit family via the shared clientOwnedUnits enumerator, so the quorum signs
+        // every client-owned unit the login replays.
+        org.keycloak.models.ProtocolMapperModel folded = new org.keycloak.models.ProtocolMapperModel();
+        folded.setId("mapper-folded-1");
+        folded.setName("custom-audience");
+        folded.setProtocol("openid-connect");
+        folded.setProtocolMapper("oidc-audience-mapper");
+        folded.setConfig(java.util.Map.of("included.custom.audience", "aud-x"));
+        // A JWT-body-irrelevant mapper (login filters it via JWT_BODY_IRRELEVANT_FACTORIES);
+        // the carrier must apply the SAME filter or it would frame a unit the login never
+        // emits (an orphaned sign) and drift from the login closure.
+        org.keycloak.models.ProtocolMapperModel irrelevant = new org.keycloak.models.ProtocolMapperModel();
+        irrelevant.setId("mapper-irrelevant-1");
+        irrelevant.setName("acr");
+        irrelevant.setProtocol("openid-connect");
+        irrelevant.setProtocolMapper("oidc-acr-mapper");
+
+        ClientModel client = mock(ClientModel.class);
+        when(client.getId()).thenReturn(CLIENT_UUID);
+        when(client.getClientId()).thenReturn("governed-app");
+        when(client.getClientScopes(org.mockito.ArgumentMatchers.anyBoolean()))
+                .thenReturn(java.util.Collections.emptyMap());
+        when(client.getScopeMappingsStream()).thenAnswer(inv -> java.util.stream.Stream.empty());
+        when(client.getProtocolMappersStream())
+                .thenAnswer(inv -> java.util.stream.Stream.of(folded, irrelevant));
+        when(client.getProtocolMapperById("mapper-folded-1")).thenReturn(folded);
+        when(client.isServiceAccountsEnabled()).thenReturn(false);
+        when(realm.getClientById(CLIENT_UUID)).thenReturn(client);
+        when(cr.getActionType()).thenReturn("CREATE_CLIENT");
+        // CREATE_CLIENT ROWS_JSON carries ID (own UUID) + CLIENT_ID (human id).
+        when(cr.getRowsJson()).thenReturn(
+                "[{\"ID\":\"" + CLIENT_UUID + "\",\"CLIENT_ID\":\"governed-app\"}]");
+
+        List<AttestationUnit> units = attestor.buildAllCrUnits(session, realm, cr, true);
+
+        assertEquals(5, units.size(),
+                "CREATE_CLIENT must frame the FULL client-owned family (config + 3 derived "
+                        + "owner-sets + 1 JWT-relevant folded mapper); got " + units.size());
+        assertEquals(AttestationUnitType.CLIENT_CONFIG, units.get(0).type(),
+                "the client_config node must stay first in the family");
+        assertEquals(CLIENT_UUID, units.get(0).targetId());
+        assertEquals(AttestationUnitType.CLIENT_SCOPE_ASSIGNMENT_SET, units.get(1).type(),
+                "the folded default/optional scope attachments' set unit must be framed");
+        assertEquals(CLIENT_UUID, units.get(1).targetId());
+        assertEquals(AttestationUnitType.CLIENT_MAPPER_SET, units.get(2).type());
+        assertEquals(CLIENT_UUID, units.get(2).targetId());
+        assertEquals(AttestationUnitType.SCOPE_ROLE_ALLOWLIST_SET, units.get(3).type());
+        assertEquals(CLIENT_UUID, units.get(3).targetId());
+        assertEquals(AttestationUnitType.PROTOCOL_MAPPER, units.get(4).type(),
+                "each JWT-relevant folded mapper must be framed as its own protocol_mapper unit");
+        assertEquals("mapper-folded-1", units.get(4).targetId());
+        assertFalse(units.stream().anyMatch(u ->
+                        u.type() == AttestationUnitType.PROTOCOL_MAPPER
+                                && "mapper-irrelevant-1".equals(u.targetId())),
+                "a JWT-body-irrelevant mapper must NOT be framed (the login never emits it)");
+
+        // Byte-identity with the producer/login builders (the VVK sig verifies over the
+        // LITERAL envelope bytes the login re-derives, so this equality is load-bearing).
+        assertArrayEquals(org.tidecloak.iga.producer.RealmAttestationExporter
+                        .clientConfig(session, client, REALM_ID).serialize(),
+                units.get(0).serialize());
+        assertArrayEquals(org.tidecloak.iga.producer.RealmAttestationExporter
+                        .clientScopeAssignmentSet(client, REALM_ID).serialize(),
+                units.get(1).serialize());
+        assertArrayEquals(org.tidecloak.iga.producer.RealmAttestationExporter
+                        .clientMapperSet(client, REALM_ID).serialize(),
+                units.get(2).serialize());
+        assertArrayEquals(org.tidecloak.iga.producer.RealmAttestationExporter
+                        .scopeRoleAllowlistSet(org.tidecloak.iga.producer.units.ParentType.client,
+                                CLIENT_UUID, client, REALM_ID).serialize(),
+                units.get(3).serialize());
+        assertArrayEquals(org.tidecloak.iga.producer.RealmAttestationExporter
+                        .protocolMapperUnit(folded,
+                                org.tidecloak.iga.producer.units.ParentType.client,
+                                CLIENT_UUID, REALM_ID).serialize(),
+                units.get(4).serialize());
+    }
+
+    @Test
     void assignScopeCr_enumeratesTheClientScopeAssignmentSet() {
         ClientModel client = mock(ClientModel.class);
         when(client.getId()).thenReturn(CLIENT_UUID);

--- a/iga-core/src/test/java/org/tidecloak/iga/attestors/TideAttestorCreateClientFamilyStampTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/attestors/TideAttestorCreateClientFamilyStampTest.java
@@ -1,0 +1,230 @@
+package org.tidecloak.iga.attestors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.tidecloak.iga.entities.IgaAuthorizerEntity;
+import org.tidecloak.iga.entities.IgaChangeRequestEntity;
+import org.tidecloak.iga.producer.RealmAttestationExporter;
+import org.tidecloak.iga.producer.units.ParentType;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * firstAdmin-lane coverage for the CREATE_CLIENT full-owned-family stamp
+ * ({@code TideAttestor.stampCreateClientUnitFamily}, routed from the CREATE_CLIENT case
+ * of {@code stampProducerUnitColumns}).
+ *
+ * <p>Regression guard for the governed-client first-login fail-close: committing a
+ * CREATE_CLIENT CR historically stamped ONLY the {@code client_config} node column
+ * (ClientEntity.attestation), leaving CLIENT_SCOPE_ASSIGNMENT_ATTESTATION,
+ * CLIENT_MAPPER_SET_ATTESTATION, SCOPE_ROLE_ALLOWLIST_ATTESTATION and each folded
+ * mapper's ProtocolMapperEntity.attestation NULL. The login exporter emits those units
+ * for the requesting client, so the first login to the new client fail-closed in
+ * {@code IgaAttestationExporterProvider.replayOrFailClosed}. On firstAdmin realms the
+ * post-commit convergence self-healed the NULLs; the stamp itself must still be complete
+ * (the multiAdmin lane, which has NO convergence backstop, shares the SAME
+ * {@code clientOwnedUnits} enumeration; see TideAttestorBuildAllCrUnitsTest).
+ *
+ * <p>Runs the NON-capable stub path (no tide-vendor-key component), so the stamped
+ * value is the deterministic SHA-256 stub over the envelope bytes; asserting the stub
+ * value therefore ALSO asserts the signed envelope bytes equal the
+ * {@link RealmAttestationExporter} builder bytes the login read replays (the
+ * byte-identity that makes the real 64-byte VVK sig verify).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TideAttestorCreateClientFamilyStampTest {
+
+    private static final String REALM_ID = "realm-uuid-createclientfam";
+    private static final String CLIENT_UUID = "client-uuid-ccf";
+    private static final String MAPPER_ID = "mapper-ccf-1";
+
+    // UnitColumnMapping's exact JPQL for the four client-owned columns + the mapper column.
+    private static final String JPQL_CLIENT_CONFIG =
+            "UPDATE ClientEntity e SET e.attestation = :sig WHERE e.id = :id";
+    private static final String JPQL_SCOPE_ASSIGNMENT =
+            "UPDATE ClientEntity e SET e.clientScopeAssignmentAttestation = :sig WHERE e.id = :id";
+    private static final String JPQL_MAPPER_SET =
+            "UPDATE ClientEntity e SET e.clientMapperSetAttestation = :sig WHERE e.id = :id";
+    private static final String JPQL_ALLOWLIST =
+            "UPDATE ClientEntity e SET e.scopeRoleAllowlistAttestation = :sig WHERE e.id = :id";
+    private static final String JPQL_PROTOCOL_MAPPER =
+            "UPDATE ProtocolMapperEntity e SET e.attestation = :sig WHERE e.id = :id";
+
+    @Mock KeycloakSession session;
+    @Mock RealmModel realm;
+    @Mock JpaConnectionProvider jpa;
+    @Mock EntityManager em;
+    @Mock IgaChangeRequestEntity cr;
+
+    private TideAttestor attestor;
+
+    /** jpql -> the :sig value the stamp bound when executeUpdate ran. */
+    private final Map<String, Object> stampedByJpql = new LinkedHashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        when(session.getProvider(JpaConnectionProvider.class)).thenReturn(jpa);
+        when(jpa.getEntityManager()).thenReturn(em);
+        when(realm.getId()).thenReturn(REALM_ID);
+        when(realm.getName()).thenReturn("ccf-realm");
+
+        // resolveMode: no IgaAuthorizer row + iga.attestor=tide -> MODE_FIRST_ADMIN.
+        @SuppressWarnings("unchecked")
+        TypedQuery<IgaAuthorizerEntity> nq = mock(TypedQuery.class);
+        when(em.createNamedQuery(eq("IgaAuthorizer.findByRealm"), eq(IgaAuthorizerEntity.class)))
+                .thenReturn(nq);
+        when(nq.setParameter(anyString(), any())).thenReturn(nq);
+        when(nq.getResultStream()).thenAnswer(inv -> Stream.empty());
+        when(realm.getAttribute("iga.attestor")).thenReturn(TideAttestor.ID);
+
+        // No tide-vendor-key component -> NOT real-signing-capable -> deterministic stub
+        // sigs (the routing contract pinned by TideAttestorAdoptProducerSignRoutingTest).
+        // Fresh stream per call (a single Stream instance would throw "already operated upon").
+        when(realm.getComponentsStream()).thenAnswer(inv -> Stream.empty());
+
+        // Record every UPDATE the stampers execute: jpql -> the bound :sig value.
+        when(em.createQuery(anyString())).thenAnswer(inv -> {
+            String jpql = inv.getArgument(0);
+            Query q = mock(Query.class);
+            Map<String, Object> params = new HashMap<>();
+            when(q.setParameter(anyString(), any())).thenAnswer(pinv -> {
+                params.put(pinv.getArgument(0), pinv.getArgument(1));
+                return q;
+            });
+            when(q.executeUpdate()).thenAnswer(einv -> {
+                stampedByJpql.put(jpql, params.get("sig"));
+                return 1;
+            });
+            when(q.getResultList()).thenReturn(java.util.Collections.emptyList());
+            return q;
+        });
+
+        // No phase-1 carrier (single-phase firstAdmin commit).
+        when(cr.getRequestModel()).thenReturn(null);
+
+        attestor = new TideAttestor(session);
+    }
+
+    private ClientModel mockClient(org.keycloak.models.ProtocolMapperModel... mappers) {
+        ClientModel client = mock(ClientModel.class);
+        when(client.getId()).thenReturn(CLIENT_UUID);
+        when(client.getClientId()).thenReturn("governed-app");
+        when(client.getClientScopes(org.mockito.ArgumentMatchers.anyBoolean()))
+                .thenReturn(java.util.Collections.emptyMap());
+        when(client.getScopeMappingsStream()).thenAnswer(inv -> Stream.empty());
+        when(client.getProtocolMappersStream()).thenAnswer(inv -> Stream.of(mappers));
+        for (org.keycloak.models.ProtocolMapperModel pm : mappers) {
+            when(client.getProtocolMapperById(pm.getId())).thenReturn(pm);
+        }
+        when(client.isServiceAccountsEnabled()).thenReturn(false);
+        when(realm.getClientById(CLIENT_UUID)).thenReturn(client);
+        return client;
+    }
+
+    private static String stubFor(byte[] envelope) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(envelope);
+        return TideAttestor.FIRSTADMIN_SIG_PREFIX + Base64.getEncoder().encodeToString(digest);
+    }
+
+    @Test
+    void createClientCommit_stampsAllFourClientColumns_andEachFoldedMapperColumn() throws Exception {
+        org.keycloak.models.ProtocolMapperModel folded = new org.keycloak.models.ProtocolMapperModel();
+        folded.setId(MAPPER_ID);
+        folded.setName("custom-audience");
+        folded.setProtocol("openid-connect");
+        folded.setProtocolMapper("oidc-audience-mapper");
+        folded.setConfig(java.util.Map.of("included.custom.audience", "aud-x"));
+        ClientModel client = mockClient(folded);
+
+        when(cr.getActionType()).thenReturn("CREATE_CLIENT");
+        when(cr.getRowsJson()).thenReturn(
+                "[{\"ID\":\"" + CLIENT_UUID + "\",\"CLIENT_ID\":\"governed-app\"}]");
+
+        attestor.stampProducerUnitColumns(session, realm, cr);
+
+        // ALL FOUR client-owned columns must be written, not just ClientEntity.attestation.
+        assertTrue(stampedByJpql.containsKey(JPQL_CLIENT_CONFIG),
+                "client_config node column must be stamped");
+        assertTrue(stampedByJpql.containsKey(JPQL_SCOPE_ASSIGNMENT),
+                "CLIENT_SCOPE_ASSIGNMENT_ATTESTATION must be stamped (the folded default-scope "
+                        + "attachments' set; its NULL was the first-login fail-close)");
+        assertTrue(stampedByJpql.containsKey(JPQL_MAPPER_SET),
+                "CLIENT_MAPPER_SET_ATTESTATION must be stamped");
+        assertTrue(stampedByJpql.containsKey(JPQL_ALLOWLIST),
+                "SCOPE_ROLE_ALLOWLIST_ATTESTATION must be stamped");
+        assertTrue(stampedByJpql.containsKey(JPQL_PROTOCOL_MAPPER),
+                "each folded protocol_mapper's own attestation column must be stamped");
+
+        // The stamped stub is deterministic over the envelope bytes, so equality with a stub
+        // computed over the EXPORTER's builder bytes proves the signed envelope equals what
+        // RealmAttestationExporter would export for this client (the login-replay bytes).
+        assertEquals(stubFor(RealmAttestationExporter
+                        .clientScopeAssignmentSet(client, REALM_ID).serialize()),
+                stampedByJpql.get(JPQL_SCOPE_ASSIGNMENT),
+                "the scope-assignment stamp must sign the exporter's exact envelope bytes");
+        assertEquals(stubFor(RealmAttestationExporter
+                        .clientConfig(session, client, REALM_ID).serialize()),
+                stampedByJpql.get(JPQL_CLIENT_CONFIG));
+        assertEquals(stubFor(RealmAttestationExporter
+                        .clientMapperSet(client, REALM_ID).serialize()),
+                stampedByJpql.get(JPQL_MAPPER_SET));
+        assertEquals(stubFor(RealmAttestationExporter
+                        .scopeRoleAllowlistSet(ParentType.client, CLIENT_UUID, client, REALM_ID)
+                        .serialize()),
+                stampedByJpql.get(JPQL_ALLOWLIST));
+        assertEquals(stubFor(RealmAttestationExporter
+                        .protocolMapperUnit(folded, ParentType.client, CLIENT_UUID, REALM_ID)
+                        .serialize()),
+                stampedByJpql.get(JPQL_PROTOCOL_MAPPER));
+    }
+
+    @Test
+    void setClientAttributeCommit_staysNodeOnly_noDerivedSetOverStamp() {
+        // Contrast guard: SET_CLIENT_ATTRIBUTE (and the other client UPDATE_* actions) must
+        // keep stamping ONLY the client_config node. The derived owner-sets were signed at
+        // create / by their own CRs; re-stamping them here would re-sign already-attested
+        // units on every client tweak.
+        mockClient();
+        when(cr.getActionType()).thenReturn("SET_CLIENT_ATTRIBUTE");
+        when(cr.getRowsJson()).thenReturn("[{\"CLIENT_UUID\":\"" + CLIENT_UUID + "\"}]");
+
+        attestor.stampProducerUnitColumns(session, realm, cr);
+
+        assertTrue(stampedByJpql.containsKey(JPQL_CLIENT_CONFIG),
+                "the client_config node column must be stamped");
+        assertFalse(stampedByJpql.containsKey(JPQL_SCOPE_ASSIGNMENT),
+                "SET_CLIENT_ATTRIBUTE must NOT re-stamp the scope-assignment set");
+        assertFalse(stampedByJpql.containsKey(JPQL_MAPPER_SET),
+                "SET_CLIENT_ATTRIBUTE must NOT re-stamp the mapper set");
+        assertFalse(stampedByJpql.containsKey(JPQL_ALLOWLIST),
+                "SET_CLIENT_ATTRIBUTE must NOT re-stamp the allowlist set");
+    }
+}


### PR DESCRIPTION
## Problem

A client created via governed CREATE_CLIENT on a **multiAdmin** realm is left with NULL attestation columns for its owned producer units (CLIENT_SCOPE_ASSIGNMENT_ATTESTATION, SCOPE_ROLE_ALLOWLIST_ATTESTATION, CLIENT_MAPPER_SET_ATTESTATION, folded mapper columns). The first login to that client then fail-closes at token mint:

```
IgaAttestationExporterProvider.replayOrFailClosed: unit client_scope_assignment_set target <clientUuid> has a NULL column
```

Root cause: KC attaches realm default/optional scopes at client creation and those ASSIGN_SCOPE side-effects are folded into the CREATE_CLIENT CR, but CREATE_CLIENT only stamped/framed client_config (+ SA user units) in both lanes. On firstAdmin realms convergeAfterCommit self-heals the NULLs; on multiAdmin realms converge is gated off, so the NULL persists and the realm's client is permanently unloginable. Live-hit on the keylessh realm.

## Fix

New shared `clientOwnedUnits(session, client, realmId, includeOwnedMappers)` enumerator consumed by all three sites so the lanes cannot drift:

- **multiAdmin lane**: `enumerateLiveCrUnits` CREATE_CLIENT now frames the full family (config, scope-assignment set, mapper set, role allowlist, folded JWT-relevant mappers); framing and `distributeMultiAdminUnitSigs` funnel through the same enumeration so sig count == unit count by construction.
- **firstAdmin lane**: `stampProducerUnitColumns` CREATE_CLIENT calls new `stampCreateClientUnitFamily`, one batched VVK ceremony, per-unit envelope bytes byte-identical to the login exporter's output.
- **ADOPT_CLIENT**: `stampAdoptClient` refactored onto the same enumerator (mappers excluded; they get ADOPT_PROTOCOL_MAPPER edge CRs).

SET/UPDATE client actions keep node-only framing (mirrors the CREATE_USER vs SET_USER_ATTRIBUTE split). convergeAfterCommit's firstAdmin gate deliberately untouched.

## Tests

- `TideAttestorBuildAllCrUnitsTest.createClientCr_enumeratesTheFullClientOwnedFamily_withFoldedMappers_byteIdentical`: 5-unit family, ordering, JWT-irrelevant mapper filtered, byte-identity vs every exporter builder.
- `TideAttestorCreateClientFamilyStampTest`: firstAdmin stamp writes all 4 client columns + folded mapper column, envelope bytes equal exporter export bytes; SET_CLIENT_ATTRIBUTE node-only contrast guard.
- Full module build green with the entire suite (no -DskipTests): targeted 15/15 pass.

## Deploy note

Pending multiAdmin CREATE_CLIENT CRs framed under the old code will fail-closed at commit after deploy (carrier sigs < new unit count): deny and re-create them. Existing NULL-column clients (e.g. keylessh's) need a data-side re-stamp via an ASSIGN_SCOPE/REMOVE_SCOPE CR cycle; this fix is forward-looking only.