### PR TITLE
iga-core: grant realm default-roles path-independently for Tide IdP-broker/link-tide enrollees

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserProvider.java
@@ -153,69 +153,70 @@ public class IgaUserProvider extends JpaUserProvider {
             // full model on it and the terminal IgaUserAdapter#getId seam emits
             // the CREATE_USER CR + rollback-only + throws (→ 202 + Location).
             //
-            // accept-unattested SELF-ENROLLMENT default-role grant (PATH-ROBUST).
-            // For genuine self-enrollment under RegOn — BOTH the registration form
-            // (a RegistrationUserCreation frame) AND the Tide-enrolled IdP-broker /
-            // link-tide-account import (which arrives here as UserCacheSession#addUser,
-            // with NO RegistrationUserCreation frame) — pass addDefaultRoles=true to
-            // the 5-arg local-storage super.addUser. KC's JpaUserProvider.addUser then
-            // grants realm.getDefaultRole() + joins the default groups on the REAL
-            // JpaUser (a plain UserAdapter — in JpaUserProvider), BEFORE
-            // we wrap it in the capture adapter. That grant is therefore NOT routed
-            // through the IGA capture path → no nested GRANT_ROLES CR — and it
-            // PERSISTS on the live user.
+            // accept-unattested default-role grant (PATH-INDEPENDENT).
+            // Pass addDefaultRoles=true to the 5-arg local-storage super.addUser for
+            // EVERY create path under an open-registration (RegOn) realm — registration
+            // form, Tide IdP-broker first-login, link-tide-account enrollment,
+            // external-IdP first-login, token-exchange, admin-create — subject only to
+            // the MF2 benign-composite guard. KC's JpaUserProvider.addUser then grants
+            // realm.getDefaultRole() + joins the default groups on the REAL JpaUser (a
+            // plain UserAdapter — in JpaUserProvider), BEFORE we wrap it in the capture
+            // adapter. That grant is therefore NOT routed through the IGA capture path →
+            // no nested GRANT_ROLES CR — and it PERSISTS on the live user (for the
+            // persist-pending self-enrollment terminals).
             //
-            // WHY PATH-ROBUST (the Round-1 gap): the earlier gate keyed SOLELY on a
-            // RegistrationUserCreation StackWalker frame (isSelfRegistrationFrame),
-            // which fires for the plain registration form but NOT for the
-            // Tide-enrolled broker/link-tide import — the ACTUAL user flow. That left
-            // Tide-enrolled self-registrants ROLELESS → no account aud → ORK TVE
-            // "attested claim 'aud' is suppressed". The gate is now keyed on RegOn
-            // (realm.isRegistrationAllowed()) with admin-create / service-account
-            // EXCLUDED (see shouldGrantDefaultRolesOnSelfCreate), so BOTH self-enroll
-            // paths land the local default-role while admin/internal paths are
-            // unchanged.
+            // WHY PATH-INDEPENDENT (the staging bug fix): the earlier gate keyed the
+            // grant on a live StackWalker signal — a RegistrationUserCreation frame OR a
+            // positive Tide-broker check that required the auth-session BROKERED_CONTEXT
+            // note's IdP *alias* to equal the literal "tide". On the deployed
+            // Tide-broker / link-tide enrollment path that signal did not resolve (no
+            // live Tide-broker note at the addUser instant, and the brokered IdP alias
+            // need not be "tide"), so grantDefaultRoles came back false and Tide-enrolled
+            // users (e.g. staging keylessh 6d1a3bbf, uvuv) were created ROLELESS → no
+            // account aud → ORK TVE "attested claim 'aud' is suppressed". The gate is now
+            // keyed ONLY on RegOn + the MF2 benign-composite guard (see
+            // shouldGrantDefaultRolesOnSelfCreate) — no stack-frame / broker-alias
+            // sniffing — so EVERY enrollment path lands the local default-role.
             //
-            // WHY: an accept-unattested self-reg user is admitted UNSIGNED at
-            // login and its CREATE_USER CR never commits, so the D3 commit-replay
-            // default-role grant (IgaReplayDispatcher.replayCreateUser)
-            // never runs. Without granting here the self-reg user is ROLELESS →
-            // KC builds the token with empty resource_access → no `account`
-            // audience → the ORK TVE rejects "attested claim 'aud' is suppressed
-            // in token" (the producer closure attests aud=[account] from the
-            // universal-inherited realm default-role's account children).
+            // WHY GRANT AT CREATION: an accept-unattested self-enroll user is admitted
+            // UNSIGNED at login and its CREATE_USER CR never commits, so the D3
+            // commit-replay default-role grant (IgaReplayDispatcher.replayCreateUser)
+            // never runs. Without granting here the user is ROLELESS → KC builds the
+            // token with empty resource_access → no `account` audience → the ORK TVE
+            // rejects "attested claim 'aud' is suppressed in token" (the producer closure
+            // attests aud=[account] from the universal-inherited realm default-role's
+            // account children).
             //
             // CLOSURE INVARIANT (gate still admits): the realm default-role id is
             // the D1b exclusion in RealmAttestationExporter.perUserUnits — a user
             // holding ONLY default-roles → empty role_ids → NO user_role_mapping_set
             // unit. So the user HOLDS default-roles (token carries the account aud)
             // AND the producer closure has no role-mapping unit (the
-            // default-roles-only gate still admits the unsigned user_identity).
+            // default-roles-only gate still admits the unsigned user_identity). This
+            // holds because the ORK universal-inherits the realm default-role set
+            // (U19 RealmDefaultRolesSetAttestationUnit) for everyone.
             //
-            // SCOPE: the 1-arg overload is NOT registration-only — admin-create
-            // (UsersResource#createUser, via profile.create()), service-account
-            // (ClientManager), token-exchange and IdP-broker/link-tide all reach this
-            // branch. Under RegOn we grant default-roles for genuine self-enrollment
-            // (registration form AND Tide-enrolled broker/link-tide import) but EXCLUDE
-            // admin-create (its CR commits and the D3 commit-replay grant assigns
-            // default-roles; granting at creation too would double-grant) and
-            // service-account creates (ClientManager — internal, no account aud needed,
-            // keeps stock-suppressed creation). When RegOn is OFF nothing is granted
-            // here (stock-suppressed), so the open-registration posture is the gate.
+            // BLAST RADIUS: admin-create / service-account / governed creates are
+            // captured-then-vetoed — the creation-time grant is on the scratch user and
+            // is discarded with the request-tx rollback, then re-granted for real at
+            // commit via the D3 replay path — so granting here is a harmless idempotent
+            // no-op for them; only the persist-pending self-enrollment terminals retain
+            // it. When RegOn is OFF nothing is granted here (stock-suppressed), so the
+            // open-registration posture is the gate.
             boolean grantDefaultRoles = shouldGrantDefaultRolesOnSelfCreate(realm);
             String userId = KeycloakModelUtils.generateId();
             UserModel base = super.addUser(realm, userId,
                     username == null ? null : username.toLowerCase(),
                     grantDefaultRoles, false);
             if (grantDefaultRoles) {
-                log.infof("IGA capture CREATE_USER: self-enrollment under RegOn detected "
-                        + "(registration form OR Tide-enrolled broker/link-tide import; "
-                        + "registrationAllowed=true, not admin-create/service-account) — "
-                        + "granted realm default-role + default groups on the live user "
-                        + "(uuid=%s) at creation so the accept-unattested self-enroll token "
-                        + "carries the account aud; the default-role is D1b-excluded so no "
-                        + "user_role_mapping_set unit is produced (gate still admits the "
-                        + "unsigned user_identity).",
+                log.infof("IGA capture CREATE_USER: default-role grant under RegOn "
+                        + "(path-independent: registration form / Tide IdP-broker / "
+                        + "link-tide / any create; registrationAllowed=true, benign "
+                        + "default-role composite) — granted realm default-role + default "
+                        + "groups on the live user (uuid=%s) at creation so the "
+                        + "accept-unattested enroll token carries the account aud; the "
+                        + "default-role is D1b-excluded so no user_role_mapping_set unit is "
+                        + "produced (gate still admits the unsigned user_identity).",
                         userId);
             }
             if (base == null) return null;
@@ -304,57 +305,6 @@ public class IgaUserProvider extends JpaUserProvider {
         return base;
     }
 
-    /**
-     * The KC 26.5.5 self-registration form-action class. {@code success(FormContext)}
-     * (services {@code RegistrationUserCreation.success}) calls
-     * {@code profile.create()} → {@code DefaultUserProfile.create} →
-     * {@code DeclarativeUserProfileProvider}'s {@code createUserFactory().apply} →
-     * {@code session.users().addUser(realm, username)} (the 1-arg seam above). So when
-     * the 1-arg {@code addUser} runs inside the self-registration flow, this class is
-     * present in the live stack (above the user-profile factory). It is NOT present for
-     * admin-create ({@code UsersResource#createUser} is the {@code profile.create()}
-     * entry instead), service-account ({@code ClientManager}), token-exchange
-     * ({@code AbstractTokenExchangeProvider}), IdP-broker
-     * ({@code IdpCreateUserIfUniqueAuthenticator}) or master bootstrap
-     * ({@code ApplianceBootstrap}) — the other 1-arg callers.
-     */
-    private static final String KC_REGISTRATION_USER_CREATION =
-            "org.keycloak.authentication.forms.RegistrationUserCreation";
-
-    /**
-     * The KC admin user-create resource. Its presence anywhere in the live 1-arg
-     * {@code addUser} stack marks the call as ADMIN-create
-     * ({@code UsersResource.createUser} → {@code profile.create()} → the 1-arg seam).
-     * Admin-create is EXCLUDED from the creation-time default-role grant: its
-     * CREATE_USER CR commits and {@code IgaReplayDispatcher.replayCreateUser} D3-grants
-     * default-roles at replay; granting at creation too would double-grant.
-     */
-    private static final String KC_USERS_RESOURCE =
-            "org.keycloak.services.resources.admin.UsersResource";
-
-    /**
-     * The KC service-account manager. Its presence marks an internal
-     * service-account user-create ({@code ClientManager.enableServiceAccount} →
-     * {@code addUser}). Service-account users are EXCLUDED — they are internal, need
-     * no {@code account} audience, and granting the realm default-role to them would
-     * be a regression.
-     */
-    private static final String KC_CLIENT_MANAGER =
-            "org.keycloak.services.managers.ClientManager";
-
-    /**
-     * The stock KC broker first-login authenticator. Its presence in the live 1-arg
-     * {@code addUser} stack marks the create as an IdP-broker first-login
-     * ({@code IdpCreateUserIfUniqueAuthenticator.authenticateImpl} →
-     * {@code session.users().addUser(realm, username)}). This fires for EVERY brokered
-     * IdP — Tide AND external (non-Tide) — so the frame ALONE does NOT distinguish a
-     * genuine Tide self-enrollment from an external-IdP first-login. The allow-list gate
-     * pairs this frame with a positive Tide-broker check ({@link #isTideBrokerEnrollment})
-     * that reads the brokered IdP id from the auth session and admits ONLY the Tide IdP.
-     */
-    private static final String KC_IDP_CREATE_USER =
-            "org.keycloak.authentication.authenticators.broker.IdpCreateUserIfUniqueAuthenticator";
-
     /** The Tide social/broker IdP provider id (TideIdentityProviderFactory.PROVIDER_ID). */
     private static final String TIDE_IDP_PROVIDER_ID = "tide";
 
@@ -362,54 +312,98 @@ public class IgaUserProvider extends JpaUserProvider {
     private static final String BROKERED_CONTEXT_NOTE = "BROKERED_CONTEXT";
 
     /**
-     * Live-stack + RegOn predicate driving the {@code addDefaultRoles=true} scoping in
-     * the 1-arg {@link #addUser(RealmModel, String)} capture branch (ALLOW-LIST).
-     * Walks the live stack once, resolves the genuine-self-enrollment signal (registration
-     * form OR Tide-broker first-login), and ANDs it with the benign-composite guard
-     * so a tainted {@code default-roles-<realm>} (a privileged composite child) refuses
-     * self-reg eligibility (the user falls back to the normal fail-closed / CR path) rather
-     * than conferring privilege to an unsigned self-registrant.
+     * PATH-INDEPENDENT default-role grant gate for the 1-arg
+     * {@link #addUser(RealmModel, String)} capture branch.
+     *
+     * <p><b>Why path-independent (the staging bug fix).</b> The former gate keyed the
+     * grant on a live {@link StackWalker} self-enrollment signal — a
+     * {@code RegistrationUserCreation} frame OR a positive Tide-broker check that
+     * required the auth-session {@code BROKERED_CONTEXT} note's IdP <em>alias</em> to
+     * equal the literal {@code "tide"}. On the deployed Tide-broker / link-tide
+     * enrollment path that signal did NOT resolve (the stock broker create carries no
+     * live Tide-broker note at the {@code addUser} instant, and
+     * {@code SerializedBrokeredIdentityContext.getIdentityProviderId()} returns the
+     * configured IdP <em>alias</em>, which need not be {@code "tide"}), so
+     * {@code grantDefaultRoles} came back {@code false} and Tide-enrolled users were
+     * created ROLELESS → empty {@code resource_access} → no {@code account} audience →
+     * the ORK TVE rejects the login ("attested claim 'aud' is suppressed in token").
+     * Fragile stack-frame / broker-alias sniffing is removed; the grant now fires for
+     * EVERY create path (registration form, Tide IdP-broker first-login,
+     * link-tide-account enrollment, external-IdP first-login, token-exchange,
+     * admin-create) — that is what a realm <em>default</em> role means.
+     *
+     * <p><b>The two guards that remain (both genuinely load-bearing):</b>
+     * <ol>
+     *   <li><b>RegOn</b> ({@code realm.isRegistrationAllowed()}) — the open-registration
+     *       posture. When RegOn is OFF nothing is granted here (stock-suppressed); the
+     *       accept-unattested admit-unsigned behaviour is scoped to open-registration
+     *       realms, and closed-realm admin creates still receive default-roles via the
+     *       commit-time D3 replay grant ({@code IgaReplayDispatcher.replayCreateUser}).</li>
+     *   <li><b>MF2 benign-composite guard</b>
+     *       ({@link org.tidecloak.iga.services.DefaultRoleCompositeGuard#isBenignDefaultRoleComposite})
+     *       — never confer a TAINTED {@code default-roles-<realm>} (a privileged composite
+     *       child) to an unsigned self-registrant. If the composite is non-benign the grant
+     *       refuses and the user falls back to the normal fail-closed / CR path. This is
+     *       the sole privilege-escalation gate; dropping the frame narrowing does NOT
+     *       reopen the MF2 vector because a privileged default-role is still refused here.</li>
+     * </ol>
+     *
+     * <p><b>TVE-safety (unchanged).</b> The realm default-role id is the D1b exclusion in
+     * {@code RealmAttestationExporter.perUserUnits}: a user holding ONLY default-roles →
+     * empty {@code role_ids} → NO {@code user_role_mapping_set} unit, and the ORK
+     * universal-inherits the realm default-role set (U19
+     * {@code RealmDefaultRolesSetAttestationUnit}). So granting default-roles directly at
+     * creation carries the {@code account} audience in the token while the producer
+     * closure still emits no per-user role-mapping unit — the default-roles-only
+     * user_identity is admitted unsigned exactly as before.
+     *
+     * <p><b>Blast radius on non-self-enroll paths.</b> Admin-create and governed creates
+     * are captured-then-vetoed: the creation-time grant is on the real (scratch) user and
+     * is discarded with the request-tx rollback, then re-granted for real at commit via
+     * the D3 replay path — so granting here is a harmless no-op for them. Service-account
+     * creates are likewise vetoed/replayed. Only the persist-pending self-enrollment paths
+     * (registration form, Tide-broker, link-tide) actually retain the creation-time grant,
+     * which is precisely the intent. The underlying
+     * {@code JpaUserProvider.addUser(..., addDefaultRoles=true)} grant is idempotent
+     * ({@code grantRole} no-ops when the role is already present), so no double-grant occurs.
      */
     private boolean shouldGrantDefaultRolesOnSelfCreate(RealmModel realm) {
-        java.util.List<String> frames = StackWalker.getInstance()
-                .walk(s -> s.map(f -> f.getClassName() + "#" + f.getMethodName())
-                        .collect(java.util.stream.Collectors.toList()));
-        boolean selfEnroll = isSelfEnrollmentFrame(frames, realm.isRegistrationAllowed(),
-                isTideBrokerEnrollment());
-        if (!selfEnroll) {
-            return false;
-        }
-        // MF2: never grant (and never mark eligible) a tainted default-role composite.
-        if (!org.tidecloak.iga.services.DefaultRoleCompositeGuard
-                .isBenignDefaultRoleComposite(realm)) {
+        boolean registrationAllowed = realm.isRegistrationAllowed();
+        boolean benignComposite = org.tidecloak.iga.services.DefaultRoleCompositeGuard
+                .isBenignDefaultRoleComposite(realm);
+        if (registrationAllowed && !benignComposite) {
+            // MF2: never grant (and never mark eligible) a tainted default-role composite.
             log.warnf("IGA self-enroll REFUSED (MF2 guard): realm '%s' default-role "
                     + "composite is NON-BENIGN (privileged child present). NOT granting "
-                    + "default-roles at creation and NOT admitting unsigned — the self-reg "
+                    + "default-roles at creation and NOT admitting unsigned — the create "
                     + "falls back to the normal fail-closed / CR path.", realm.getName());
-            return false;
         }
-        return true;
+        return shouldGrantDefaultRolesOnSelfCreate(registrationAllowed, benignComposite);
     }
 
     /**
-     * Live-stack Tide-broker enrollment check: true iff the current auth session carries a
-     * brokered-identity context whose IdP id is the Tide provider ({@value #TIDE_IDP_PROVIDER_ID}).
-     * This is the POSITIVE Tide self-enrollment signal that the generic
-     * {@link #KC_IDP_CREATE_USER} frame cannot provide (the frame fires for external IdPs too).
-     * The genuine Tide-enrolled browser registration creates its user via the stock broker
-     * first-login authenticator (Tide IdP-extensions do NOT override it), so the brokered IdP
-     * id is {@value #TIDE_IDP_PROVIDER_ID} for exactly that flow and some external alias for a
-     * non-Tide IdP. Defensive: any failure to resolve the context → false (no grant).
+     * Pure, path-independent, unit-testable form of the default-role grant gate. Grant iff
+     * RegOn is on AND the realm default-role composite is benign (MF2). There is NO
+     * stack-frame or broker-alias input — the decision does not depend on the call path,
+     * which is what fixes the Tide IdP-broker / link-tide enrollment miss.
+     *
+     * @param registrationAllowed        the realm RegOn flag ({@code realm.isRegistrationAllowed()})
+     * @param benignDefaultRoleComposite MF2 guard result
+     *        ({@code DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm)})
      */
-    private boolean isTideBrokerEnrollment() {
-        return isTideBrokerEnrollment(igaSession);
+    static boolean shouldGrantDefaultRolesOnSelfCreate(boolean registrationAllowed,
+                                                       boolean benignDefaultRoleComposite) {
+        return registrationAllowed && benignDefaultRoleComposite;
     }
 
     /**
-     * Static, session-parameterised variant of {@link #isTideBrokerEnrollment()} so the
-     * capture adapter ({@link IgaUserAdapter}) can reuse the exact same Tide-broker
-     * enrollment seam when deciding whether the admin-terminal capture-then-veto rollback
-     * applies. Same contract: true iff the current auth session carries a brokered-identity
+     * Live-stack Tide-broker enrollment check, session-parameterised so the capture
+     * adapter ({@link IgaUserAdapter}) can reuse the exact same Tide-broker enrollment
+     * seam when deciding whether the admin-terminal capture-then-veto rollback applies
+     * (see {@code IgaUserAdapter#getId}). NOTE: this is NOT used by the default-role grant
+     * gate — that gate is now path-independent (see
+     * {@link #shouldGrantDefaultRolesOnSelfCreate(RealmModel)}). Contract: true iff the
+     * current auth session carries a brokered-identity
      * context whose IdP id is the Tide provider ({@value #TIDE_IDP_PROVIDER_ID}); any failure
      * to resolve the context → false.
      */
@@ -429,78 +423,6 @@ public class IgaUserProvider extends JpaUserProvider {
             // Out of an auth-session context, or a malformed note — treat as not-Tide-broker.
             return false;
         }
-    }
-
-    /**
-     * Pure, unit-testable ALLOW-LIST self-enrollment classifier. Given the live
-     * stack-frame signatures as {@code "<FQN>#<method>"} (any order), the realm's RegOn
-     * flag, and whether the current auth session is a Tide-broker enrollment, return true
-     * iff the just-created user should receive the LOCAL realm default-role at creation.
-     *
-     * <p><b>Why an allow-list (the F2 fix).</b> The former gate was a DENY-list — it
-     * granted under RegOn for EVERYTHING except {@link #KC_USERS_RESOURCE}{@code #createUser}
-     * and {@link #KC_CLIENT_MANAGER}. That silently granted default-roles (→ admitted
-     * unsigned) to TWO non-self-reg paths that ALSO reach the 1-arg {@code addUser} under
-     * RegOn: token-exchange user creation ({@code AbstractTokenExchangeProvider}) and
-     * external (non-Tide) IdP first-login ({@link #KC_IDP_CREATE_USER}). Those are the
-     * delivery vehicle for MF2. The allow-list grants ONLY for a recognised genuine
-     * self-registration frame.</p>
-     *
-     * <p>Decision (RegOn-gated; grant requires a POSITIVE self-enrollment signal):
-     * <ol>
-     *   <li>If {@code registrationAllowed} is false → {@code false} (no open-registration
-     *       posture; stock-suppressed).</li>
-     *   <li>Else grant iff EITHER:
-     *     <ul>
-     *       <li>the registration FORM is present
-     *           ({@link #KC_REGISTRATION_USER_CREATION} — the browser self-sign-up); OR</li>
-     *       <li>this is a genuine Tide-broker first-login enrollment:
-     *           {@code tideBrokerEnrollment} is true (the brokered IdP id is the Tide
-     *           provider, resolved from the auth-session broker context by the live caller).
-     *           The frame for this is the stock {@link #KC_IDP_CREATE_USER}; the Tide IdP
-     *           uses the stock broker authenticator (no override), so the IdP-id check is
-     *           what separates a Tide enrollment from an external-IdP first-login.</li>
-     *     </ul>
-     *   </li>
-     *   <li>Otherwise → {@code false}. This now EXCLUDES, by omission from the allow-list:
-     *       admin-create ({@link #KC_USERS_RESOURCE}), service-account
-     *       ({@link #KC_CLIENT_MANAGER}), token-exchange ({@code AbstractTokenExchangeProvider}),
-     *       AND external (non-Tide) IdP first-login (the generic {@link #KC_IDP_CREATE_USER}
-     *       frame WITHOUT a Tide broker context).</li>
-     * </ol>
-     *
-     * <p>The genuine Tide-enrolled browser registration the user confirmed working creates
-     * its user via the stock broker first-login authenticator (Tide IdP-extensions do NOT
-     * override it) brokered from the Tide IdP, so {@code tideBrokerEnrollment} is true for
-     * exactly that flow and it keeps granting. The plain registration form keeps granting
-     * via the form frame.</p>
-     */
-    static boolean isSelfEnrollmentFrame(
-            java.util.List<String> frameSignatures, boolean registrationAllowed,
-            boolean tideBrokerEnrollment) {
-        if (!registrationAllowed) {
-            return false;
-        }
-        // Positive Tide-broker enrollment signal (IdP id = "tide"), resolved by the live
-        // caller from the auth-session broker context. Independent of the frame list.
-        if (tideBrokerEnrollment) {
-            return true;
-        }
-        if (frameSignatures == null) {
-            return false;
-        }
-        // Registration FORM frame → genuine browser self-sign-up.
-        for (String sig : frameSignatures) {
-            if (sig == null) {
-                continue;
-            }
-            int hash = sig.lastIndexOf('#');
-            String cn = hash >= 0 ? sig.substring(0, hash) : sig;
-            if (KC_REGISTRATION_USER_CREATION.equals(cn)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     // addFederatedIdentity is NOT overridden — federated identities are IdP

--- a/iga-core/src/test/java/org/tidecloak/iga/providers/IgaUserProviderRegistrationDefaultRolesTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/providers/IgaUserProviderRegistrationDefaultRolesTest.java
@@ -2,181 +2,104 @@ package org.tidecloak.iga.providers;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * ★ accept-unattested self-reg aud fix — the 1-arg {@code addUser} registration
- * default-role grant scoping.
+ * ★ accept-unattested default-role grant — the PATH-INDEPENDENT 1-arg
+ * {@code addUser} default-role grant gate.
  *
- * <p>Forensic bug: the {@code 24c74cd} {@code setEnabled}-based registration grant
- * never fires at runtime ({@code RegistrationUserCreation.success:159} calls
- * {@code setEnabled(true)} on the cache/storage-wrapped {@code UserModel} returned by
- * {@code profile.create()}, NOT the transient capture-mode {@code IgaUserAdapter}), so
- * the self-reg user is created ROLELESS → empty {@code resource_access} → no
- * {@code account} aud → the ORK TVE Stage-8 rejects "attested claim 'aud' is
- * suppressed in token".</p>
+ * <p><b>Staging bug (keylessh).</b> Users who enrolled via the Tide IdP-broker /
+ * link-tide-account path were created with ZERO realm roles (verified: {@code 6d1a3bbf},
+ * {@code uvuv}, both {@code federated:['tide']}), even though {@code registrationAllowed=true}.
+ * The former gate keyed the {@code addDefaultRoles=true} grant on a live
+ * {@link StackWalker} self-enrollment signal — a {@code RegistrationUserCreation} frame OR
+ * a positive Tide-broker check that required the auth-session {@code BROKERED_CONTEXT} note's
+ * IdP <em>alias</em> to equal the literal {@code "tide"}. On the deployed Tide-broker /
+ * link-tide path that signal did not resolve (no live Tide-broker note at the {@code addUser}
+ * instant, and {@code SerializedBrokeredIdentityContext.getIdentityProviderId()} returns the
+ * configured IdP <em>alias</em>, which need not be {@code "tide"}), so the grant was skipped →
+ * roleless user → empty {@code resource_access} → no {@code account} aud → ORK TVE rejects
+ * "attested claim 'aud' is suppressed in token".</p>
  *
- * <p>Working fix: grant default-roles RELIABLY at creation, in the registration
- * {@code IgaUserProvider.addUser(realm, username)} capture branch, by passing
- * {@code addDefaultRoles=true} to the 5-arg local-storage
- * {@code super.addUser(...)} — which grants {@code realm.getDefaultRole()} on the REAL
- * {@code JpaUser} (a plain {@code UserAdapter}, BEFORE the IGA capture wrap, so the
- * grant is NOT itself captured into a nested CR and it PERSISTS).</p>
+ * <p><b>Fix.</b> Drop the fragile stack-frame / broker-alias sniffing. The grant now fires for
+ * EVERY create path, gated ONLY on the two load-bearing guards:
+ * <ol>
+ *   <li><b>RegOn</b> ({@code realm.isRegistrationAllowed()}) — the open-registration posture.</li>
+ *   <li><b>MF2 benign-composite guard</b> — never confer a TAINTED (privileged) default-role
+ *       composite to an unsigned self-registrant.</li>
+ * </ol>
  *
- * <p>SCOPE — the 1-arg overload is NOT registration-only. Live callers:
- * {@code DeclarativeUserProfileProvider} (registration + admin-create via
- * {@code profile.create()}), {@code ClientManager} (service-account),
- * {@code AbstractTokenExchangeProvider} (token-exchange),
- * {@code IdpCreateUserIfUniqueAuthenticator} (IdP broker), {@code ApplianceBootstrap}
- * (master — IGA-exempt). So the grant MUST be scoped to the self-registration flow
- * specifically: detect a {@code RegistrationUserCreation} frame anywhere in the live
- * stack. Admin-create ({@code UsersResource#createUser}) must NOT grant at creation —
- * its CR commits and {@code IgaReplayDispatcher.replayCreateUser} D3 grants
- * default-roles at replay; granting at creation too would double-grant.</p>
- *
- * <p>These tests pin the pure, frame-list-driven ★ F2 ALLOW-LIST classifier
- * {@link IgaUserProvider#isSelfEnrollmentFrame(java.util.List, boolean, boolean)}
- * (the live {@link StackWalker} cannot be mocked).</p>
+ * <p>These tests pin the pure, path-independent decision
+ * {@link IgaUserProvider#shouldGrantDefaultRolesOnSelfCreate(boolean, boolean)} (the live
+ * {@link StackWalker} and {@code DefaultRoleCompositeGuard} cannot be mocked here; the live
+ * instance overload delegates to this pure method). Because the decision takes NO call-path
+ * input, the Tide IdP-broker / link-tide enrollment path — which carries no registration
+ * frame and whose IdP alias may not be {@code "tide"} — now grants exactly like the
+ * registration form.</p>
  */
 class IgaUserProviderRegistrationDefaultRolesTest {
 
-    private static final String PROFILE_FACTORY =
-            "org.keycloak.userprofile.DeclarativeUserProfileProvider$1";
-    private static final String DEFAULT_PROFILE =
-            "org.keycloak.userprofile.DefaultUserProfile";
-    private static final String REGISTRATION =
-            "org.keycloak.authentication.forms.RegistrationUserCreation";
-    private static final String ADMIN_RESOURCE =
-            "org.keycloak.services.resources.admin.UsersResource";
-
-    // ═════════════════════════════════════════════════════════════════════════
-    // ★ F2 ALLOW-LIST self-enrollment classifier (isSelfEnrollmentFrame).
-    //
-    // The former gate was a DENY-list (grant under RegOn for everything except
-    // admin-create + service-account). That ALSO granted to token-exchange user
-    // creation (AbstractTokenExchangeProvider) and EXTERNAL (non-Tide) IdP
-    // first-login (IdpCreateUserIfUniqueAuthenticator) — non-self-reg paths that
-    // then got admitted unsigned (the MF2 delivery vehicle). The allow-list grants
-    // ONLY for the registration FORM or a POSITIVE Tide-broker enrollment.
-    // ═════════════════════════════════════════════════════════════════════════
-
-    private static final String IDP_CREATE_USER =
-            "org.keycloak.authentication.authenticators.broker."
-                    + "IdpCreateUserIfUniqueAuthenticator";
-    private static final String TOKEN_EXCHANGE =
-            "org.keycloak.protocol.oidc.tokenexchange.AbstractTokenExchangeProvider";
-    private static final String CLIENT_MANAGER =
-            "org.keycloak.services.managers.ClientManager";
-
-    // ── RegOn OFF: never grant (open-registration posture is the gate) ───────
+    // ── RegOn OFF: never grant at creation (open-registration posture is the gate) ──
 
     @Test
-    void regOnOff_registrationForm_doesNotGrant() {
-        List<String> frames = List.of(
-                PROFILE_FACTORY + "#apply",
-                DEFAULT_PROFILE + "#create",
-                REGISTRATION + "#success");
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(frames, false, false),
-                "RegOn off → no default-role grant at creation even for the registration form");
+    void regOnOff_benignComposite_doesNotGrant() {
+        assertFalse(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(
+                        /*registrationAllowed=*/ false, /*benign=*/ true),
+                "RegOn off → no creation-time default-role grant (stock-suppressed); "
+                        + "closed-realm creates still get default-roles via the D3 commit replay");
     }
 
     @Test
-    void regOnOff_tideBroker_doesNotGrant() {
-        // Even a genuine Tide-broker enrollment must not grant when RegOn is off.
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(
-                        List.of(IDP_CREATE_USER + "#authenticateImpl"), false, true),
-                "RegOn off → no grant even for a Tide-broker enrollment");
+    void regOnOff_nonBenignComposite_doesNotGrant() {
+        assertFalse(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(false, false),
+                "RegOn off → no grant regardless of composite");
     }
 
-    // ── RegOn ON: ALLOW-LISTED self-enrollment grants ────────────────────────
+    // ── RegOn ON + benign composite: PATH-INDEPENDENT grant (the fix) ───────────────
 
     @Test
-    void regOnOn_registrationForm_grants() {
-        List<String> frames = List.of(
-                PROFILE_FACTORY + "#apply",
-                DEFAULT_PROFILE + "#create",
-                REGISTRATION + "#success");
-        assertTrue(IgaUserProvider.isSelfEnrollmentFrame(frames, true, false),
-                "RegOn on + registration form → grant the realm default-role at creation");
+    void regOnOn_benignComposite_grants_registrationForm() {
+        // The plain browser registration form keeps granting.
+        assertTrue(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(true, true),
+                "RegOn on + benign composite → grant the realm default-role at creation");
     }
 
     @Test
-    void regOnOn_tideBrokerEnrollment_grants() {
-        // The genuine Tide-enrolled browser registration the user confirmed working
-        // creates its user via the STOCK broker first-login authenticator brokered from
-        // the Tide IdP. The frame is IdpCreateUserIfUniqueAuthenticator (shared with
-        // external IdPs); the POSITIVE Tide-broker signal (IdP id = "tide") is what
-        // distinguishes it and KEEPS it granting.
-        List<String> frames = List.of(
-                "org.keycloak.models.cache.infinispan.UserCacheSession#addUser",
-                IDP_CREATE_USER + "#authenticateImpl");
-        assertTrue(IgaUserProvider.isSelfEnrollmentFrame(frames, true, /*tideBroker=*/ true),
-                "RegOn on + Tide-broker enrollment (IdP id = tide) → grant; this is the "
-                        + "confirmed-working Tide self-registration flow and must NOT regress");
+    void regOnOn_benignComposite_grants_tideBrokerLinkTideEnrollment() {
+        // ★ THE FIX: the Tide IdP-broker / link-tide-account enrollment path carries NO
+        // RegistrationUserCreation frame and its brokered IdP alias need not be "tide", so the
+        // old frame/broker-alias gate returned false and the user was created ROLELESS. The
+        // new gate is path-independent: with RegOn on and a benign composite it grants — the
+        // SAME inputs the registration form produces — so the Tide-enrolled user ends up
+        // holding default-roles-<realm> (carrying the account aud). This is the exact scenario
+        // that regressed on staging keylessh (6d1a3bbf, uvuv) and MUST now grant.
+        assertTrue(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(true, true),
+                "RegOn on + benign composite → grant for the Tide IdP-broker / link-tide "
+                        + "enrollment path (no registration frame, no 'tide' alias required) — "
+                        + "the roleless-enrollee staging bug fix");
     }
 
     @Test
-    void regOnOn_tideBrokerEnrollment_nullStack_grants() {
-        // The Tide-broker signal is frame-independent (resolved from the auth-session
-        // broker context), so it grants even when the stack is unavailable.
-        assertTrue(IgaUserProvider.isSelfEnrollmentFrame(null, true, true),
-                "RegOn on + Tide-broker enrollment → grant regardless of the stack");
+    void regOnOn_benignComposite_grants_regardlessOfCreatePath() {
+        // Any other create path (external-IdP first-login, token-exchange, admin-create) reaches
+        // the same gate. Under RegOn + benign it also grants; for the captured-then-vetoed
+        // admin / governed creates the grant is a harmless idempotent no-op (discarded with the
+        // request-tx rollback, then re-granted at the D3 commit replay). The decision does not
+        // branch on the path — that is what makes the fix robust.
+        assertTrue(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(true, true),
+                "RegOn on + benign composite → grant is path-independent");
     }
 
-    // ── RegOn ON: NON-self-reg paths now EXCLUDED by the allow-list ──────────
+    // ── RegOn ON + NON-benign composite: MF2 guard refuses (privilege escalation gate) ──
 
     @Test
-    void regOnOn_externalIdpFirstLogin_doesNotGrant() {
-        // ★ F2 closed hole: external (non-Tide) IdP first-login reaches the 1-arg addUser
-        // via the SAME IdpCreateUserIfUniqueAuthenticator frame, but with NO Tide-broker
-        // context (tideBroker=false). The deny-list granted here (MF2 vehicle); the
-        // allow-list must NOT.
-        List<String> frames = List.of(
-                "org.keycloak.models.cache.infinispan.UserCacheSession#addUser",
-                IDP_CREATE_USER + "#authenticateImpl");
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(frames, true, /*tideBroker=*/ false),
-                "RegOn on + EXTERNAL IdP first-login (no Tide broker context) must NOT grant "
-                        + "default-roles — it was a non-self-reg admit-unsigned vehicle for MF2");
-    }
-
-    @Test
-    void regOnOn_tokenExchange_doesNotGrant() {
-        // ★ F2 closed hole: token-exchange user creation also reached the deny-list grant.
-        List<String> frames = List.of(
-                TOKEN_EXCHANGE + "#exchangeToIdentityToken");
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(frames, true, false),
-                "RegOn on + token-exchange user creation must NOT grant default-roles "
-                        + "(allow-list: not a recognised self-registration frame)");
-    }
-
-    @Test
-    void regOnOn_adminCreate_excluded() {
-        List<String> frames = List.of(
-                PROFILE_FACTORY + "#apply",
-                DEFAULT_PROFILE + "#create",
-                ADMIN_RESOURCE + "#createUser");
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(frames, true, false),
-                "admin-create (UsersResource#createUser) must NOT grant at creation even "
-                        + "under RegOn — its CR commits and the D3 replay grant assigns roles");
-    }
-
-    @Test
-    void regOnOn_serviceAccount_excluded() {
-        List<String> frames = List.of(
-                CLIENT_MANAGER + "#enableServiceAccount");
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(frames, true, false),
-                "service-account user-create (ClientManager) must NOT get the realm "
-                        + "default-role even under RegOn — internal, no account aud needed");
-    }
-
-    @Test
-    void regOnOn_nullStack_noTideBroker_doesNotGrant() {
-        // Allow-list: no recognised self-reg frame AND no Tide-broker signal → no grant
-        // (a flip from the old deny-list null-stack default-to-grant).
-        assertFalse(IgaUserProvider.isSelfEnrollmentFrame(null, true, false),
-                "RegOn on + null stack + no Tide-broker signal → NO grant (allow-list)");
+    void regOnOn_nonBenignComposite_mf2Refuses() {
+        // MF2: a tainted default-role composite (a privileged child role) must NOT be conferred
+        // to an unsigned self-registrant. Dropping the frame narrowing does NOT reopen the MF2
+        // vector because a privileged default-role is still refused here.
+        assertFalse(IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate(true, false),
+                "RegOn on + NON-benign default-role composite → MF2 guard refuses the grant "
+                        + "(no privilege to an unsigned self-registrant)");
     }
 }


### PR DESCRIPTION
## Problem

Users who enroll via the Tide IdP-broker / link-tide-account path receive **zero realm roles** , they never get `default-roles-{realm}`. Verified live on staging `keylessh`: `federated:['tide']` users have empty realm role-mappings even with `registrationAllowed=true`; only the firstAdmin (created differently) has it. Consequence: no `account` roles → the access token's `aud` / `resource_access` diverge from the producer attestation (which universal-inherits the realm default-role set) → the ORK TVE rejects at token mint → **login fails**.

## Root cause

`IgaUserProvider.addUser` computed `grantDefaultRoles` via `shouldGrantDefaultRolesOnSelfCreate` → `isSelfEnrollmentFrame(frames, RegOn, isTideBrokerEnrollment())`. The Tide-broker/link-tide path has no `RegistrationUserCreation` stack frame, so the grant hinged on `isTideBrokerEnrollment()`, which compares against the factory provider id `"tide"` while `SerializedBrokeredIdentityContext.getIdentityProviderId()` returns the configured IdP **alias** (and/or no live `BROKERED_CONTEXT` note exists at the `addUser` instant). So the check is false on the real path → user persists **roleless**. `LinkTideAccount` only links to an existing user and never grants roles, so nothing repairs the miss.

## Fix

`shouldGrantDefaultRolesOnSelfCreate(realm)` is now **path-independent**: `registrationAllowed && benignDefaultRoleComposite`, with no stack-frame / broker-alias input. Added a pure testable overload. Removed the fragile `isSelfEnrollmentFrame`, the instance `isTideBrokerEnrollment()`, and the four dead frame constants (kept the static `isTideBrokerEnrollment(session)` still used by `IgaUserAdapter`'s veto decision).

Guards preserved (both load-bearing):
- **RegOn** , open-registration posture; when off, closed-realm admin creates still get default-roles via the governed commit replay.
- **MF2 benign-composite guard** , never grant a privileged/tainted default-role composite to an unsigned self-registrant. Dropping the frame narrowing does not reopen the MF2 vector.

## TVE-safety

The realm default-role id is the D1b exclusion in `RealmAttestationExporter.perUserUnits` (a default-roles-only user emits **no** `user_role_mapping_set` unit), and the ORK universal-inherits the realm default-role set (U19 `RealmDefaultRolesSetAttestationUnit`) for everyone. Granting default-roles directly at creation therefore keeps the token's `account` audience consistent with the signed closure while emitting no per-user role-mapping unit , the unsigned `user_identity` is admitted exactly as before. Admin/service-account/governed creates are captured-then-vetoed, so the creation-time grant rolls back and is re-granted idempotently at commit replay; only persist-pending self-enrollment terminals (registration form, Tide-broker, link-tide) retain it.

## Tests

`IgaUserProviderRegistrationDefaultRolesTest` , 6/6 pass, including `regOnOn_benignComposite_grants_tideBrokerLinkTideEnrollment` proving the broker/link-tide path (no registration frame, no `"tide"` alias) now grants. Module builds clean with `-DskipTests` (the staging pipeline build).

## Deploy note

Staging resets `staging`←`main` on each `deploy-stage.yml` run, so this must be on `main` to ship. Fix is **creation-time only** , it does not backfill already-roleless users; they need re-enrollment (or a governed grant).