### PR TITLE
iga-core: fix benign-composite guard so Tide self-registrants get default roles

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/services/DefaultRoleCompositeGuard.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/services/DefaultRoleCompositeGuard.java
@@ -12,16 +12,17 @@ import org.keycloak.models.RoleModel;
 
 /**
  * MF2 (HIGH) guard — validates that the realm composite default-role
- * ({@code default-roles-<realm>}) expands ONLY to a benign, non-privileged
- * baseline before the accept-unattested self-registration model trusts it.
+ * ({@code default-roles-<realm>}) does NOT expand to any <em>privileged /
+ * realm-escalation</em> role before the accept-unattested self-registration
+ * model trusts it.
  *
  * <h2>The hole this closes</h2>
  * The whole accept-unattested self-enrollment model trusts that
- * {@code default-roles-<realm>} confers only benign {@code account} baseline —
- * but NOTHING validated that. If an admin (or a committed CR) adds a privileged
- * role ({@code tide-realm-admin}, {@code manage-users}, any
- * {@code realm-management} client role) as a COMPOSITE CHILD of the default
- * role:
+ * {@code default-roles-<realm>} confers only a non-privileged baseline — but
+ * NOTHING validated that. If an admin (or a committed CR) adds a privileged
+ * role ({@code tide-realm-admin}, any {@code realm-management} client role such
+ * as {@code manage-users} / {@code manage-realm} / {@code realm-admin}) as a
+ * COMPOSITE CHILD of the default role:
  * <ul>
  *   <li>the creation-time / persist-pending grant
  *       ({@code IgaUserProvider.addUser} /
@@ -38,28 +39,55 @@ import org.keycloak.models.RoleModel;
  *       the closure.</li>
  * </ul>
  *
- * <h2>The guard</h2>
- * Walk the {@code default-roles-<realm>} composite TRANSITIVELY (cycle-safe) and
- * fail-closed if ANY leaf is not on the benign allowlist. "Benign" is an
- * ALLOWLIST (not a deny-list — an unknown role is tainted, never benign):
+ * <h2>The guard: a privileged-role DENYLIST walked transitively</h2>
+ * <p>An earlier revision used a strict <em>allowlist</em> (only
+ * {@code offline_access} / {@code uma_authorization} + the stock {@code account}
+ * baseline were "benign", everything else tainted). That was too strict: a
+ * normal realm default-role composite legitimately also contains the operator's
+ * application baseline role (e.g. {@code appUser}) and Tide's self-scoped E2EE
+ * roles ({@code _tide_dob.selfencrypt} / {@code _tide_dob.selfdecrypt}). The
+ * allowlist classified those NON-privileged application roles as tainted, so the
+ * grant was refused and Tide self-registrants were created ROLELESS (empty
+ * {@code resource_access} → no {@code account} audience → ORK TVE rejects the
+ * login: "attested claim 'aud' is suppressed in token").</p>
+ *
+ * <p>The guard is now a <b>denylist of the realm-escalation surface</b>. Walk
+ * {@code default-roles-<realm>} TRANSITIVELY (cycle-safe) and fail-closed if ANY
+ * transitively-reachable leaf is a <em>privileged</em> role. A role is
+ * privileged iff it is on the Keycloak/Tide realm-administration surface:</p>
  * <ul>
- *   <li>the realm composite root {@code default-roles-<realm>} itself (the node
- *       we are expanding) and any nested composite that is itself only a
- *       grouping of benign leaves;</li>
- *   <li>the two stock default realm roles {@code offline_access},
- *       {@code uma_authorization} (see {@link IgaSystemEntityFilter#DEFAULT_REALM_ROLE_NAMES});</li>
- *   <li>the stock {@code account} / {@code account-console} client baseline
- *       roles ({@link #BENIGN_ACCOUNT_CLIENT_IDS} ×
- *       {@link #BENIGN_ACCOUNT_ROLE_NAMES}: view-profile, manage-account,
- *       manage-account-links, view-applications, view-consent, manage-consent,
- *       delete-account, view-groups).</li>
+ *   <li>ANY client role under the {@code realm-management} client — the entire
+ *       KC admin authorization surface ({@code manage-users}, {@code manage-realm},
+ *       {@code manage-clients}, {@code realm-admin}, {@code view-users},
+ *       {@code impersonation}, {@code tide-realm-admin}, …). Realm authorization
+ *       in Keycloak flows through these roles, so the whole client is privileged
+ *       by definition;</li>
+ *   <li>the Tide approver role {@code tide-realm-admin} by NAME wherever it
+ *       appears (defense-in-depth — it lives on {@code realm-management}, but we
+ *       also reject it if ever re-homed);</li>
+ *   <li>a REALM role whose bare name denotes realm administration
+ *       ({@link #PRIVILEGED_REALM_ROLE_NAMES}: {@code admin}, {@code realm-admin},
+ *       {@code create-realm}) — belt-and-suspenders for names that strongly imply
+ *       realm control.</li>
  * </ul>
- * EVERYTHING ELSE is tainted: any {@code realm-management} client role,
- * {@code tide-realm-admin}, any client role under a non-account client, and any
- * realm role not in the benign set (this catches {@code admin},
- * {@code manage-*}, {@code realm-admin}, and any operator-authored role we
- * cannot positively classify). On taint we emit a LOUD {@code ERROR} naming the
- * offending child + realm and return {@code false}.
+ *
+ * <p>EVERYTHING ELSE is benign: the composite root {@code default-roles-<realm>}
+ * itself, the stock default realm roles, the stock {@code account} self-service
+ * roles, the operator's application roles ({@code appUser} and any other
+ * non-privileged realm/client role), and the self-scoped {@code _tide_*} E2EE
+ * encrypt/decrypt roles. None of those confer control of the realm — they are
+ * exactly the "default" baseline an operator intends every user to hold, which
+ * is what a realm <em>default</em> role means.</p>
+ *
+ * <h2>Why a denylist + transitive walk is still fail-safe</h2>
+ * The transitive walk descends into EVERY composite, so even if an operator
+ * hides {@code realm-management:realm-admin} beneath a benignly-named grouping
+ * role, the walk reaches the privileged LEAF and refuses. The denylist only
+ * changes the treatment of <em>unknown NON-privileged</em> roles (they are now
+ * accepted, which is the whole point — {@code appUser}/{@code _tide_*} are
+ * unknown-but-benign application roles that legitimately belong on the default
+ * composite). The escalation vector (a privileged child conferred to unsigned
+ * self-registrants) stays closed because every privileged leaf is still refused.
  *
  * <p>Stateless utility. The pure leaf classifier {@link #isBenignChild(boolean,
  * String, String, String)} is unit-testable without a realm; the realm walk
@@ -69,27 +97,27 @@ public final class DefaultRoleCompositeGuard {
 
     private static final Logger log = Logger.getLogger(DefaultRoleCompositeGuard.class);
 
-    /** The {@code account} surface clients whose baseline roles are benign. */
-    public static final Set<String> BENIGN_ACCOUNT_CLIENT_IDS = Set.of(
-            "account",
-            "account-console"
-    );
+    /**
+     * The Keycloak admin-authorization client. EVERY role under this client is
+     * privileged (it is the realm-management surface: manage-users, manage-realm,
+     * realm-admin, view-users, impersonation, tide-realm-admin, …). Mirrors the
+     * canonical clientId used by {@link TideRealmAdminGuard} /
+     * {@link IgaSystemEntityFilter#BUILTIN_CLIENT_IDS}.
+     */
+    public static final String REALM_MANAGEMENT_CLIENT_ID = "realm-management";
 
     /**
-     * The stock {@code account} client baseline roles (Keycloak 26.5.5
-     * {@code AccountRoles}). These are the only client roles a benign
-     * default-role composite may confer. NOTE: {@code realm-management} roles are
-     * NEVER benign — they are privileged by definition.
+     * Bare REALM-role names that denote realm administration / escalation and are
+     * refused wherever they appear on the default-role composite. Keycloak
+     * authorization actually flows through {@code realm-management} client roles
+     * (covered above), so this is defense-in-depth for names that unambiguously
+     * imply realm control. No legitimate default-role composite contains a realm
+     * role with one of these names.
      */
-    public static final Set<String> BENIGN_ACCOUNT_ROLE_NAMES = Set.of(
-            "view-profile",
-            "manage-account",
-            "manage-account-links",
-            "view-applications",
-            "view-consent",
-            "manage-consent",
-            "delete-account",
-            "view-groups"
+    public static final Set<String> PRIVILEGED_REALM_ROLE_NAMES = Set.of(
+            "admin",
+            "realm-admin",
+            "create-realm"
     );
 
     private DefaultRoleCompositeGuard() {
@@ -98,55 +126,67 @@ public final class DefaultRoleCompositeGuard {
     /**
      * Pure, unit-testable single-leaf classifier. Given a role's
      * (isClientRole, name, owning-clientId-or-null) and the realm's
-     * {@code default-roles-<realm>} composite-root name, return true iff the role
-     * is on the benign allowlist.
+     * {@code default-roles-<realm>} composite-root name, return {@code true} iff
+     * the role is NON-privileged (benign).
      *
-     * <p>ALLOWLIST semantics — an unrecognised role is NOT benign:</p>
+     * <p>DENYLIST semantics — a role is benign unless it is on the realm-escalation
+     * surface (see {@link #isPrivilegedChild}):</p>
      * <ol>
-     *   <li>The composite root {@code default-roles-<realm>} itself (a realm role)
-     *       is benign (it is the node being expanded / a benign grouping).</li>
-     *   <li>A REALM role is benign iff it is {@code offline_access} or
-     *       {@code uma_authorization} (the stock default realm roles) OR the
-     *       composite root. Every other realm role (incl. {@code admin},
-     *       {@code manage-*}, {@code tide-realm-admin} if ever modelled as a realm
-     *       role, operator-authored roles) is TAINTED.</li>
-     *   <li>A CLIENT role is benign iff its owning client is
-     *       {@code account}/{@code account-console} AND its name is one of the
-     *       stock account baseline roles. Every {@code realm-management} role
-     *       (manage-users, manage-realm, realm-admin, tide-realm-admin, …) and
-     *       every role under any other client is TAINTED.</li>
+     *   <li>a {@code null} name is fail-closed (we cannot classify it) → NOT benign;</li>
+     *   <li>a CLIENT role under {@code realm-management} is privileged → NOT benign;</li>
+     *   <li>the {@code tide-realm-admin} role (by name, any container) is
+     *       privileged → NOT benign;</li>
+     *   <li>a REALM role in {@link #PRIVILEGED_REALM_ROLE_NAMES} is privileged →
+     *       NOT benign;</li>
+     *   <li>everything else (the composite root {@code default-roles-<realm>}, the
+     *       stock default realm roles, the {@code account} baseline, the operator's
+     *       {@code appUser} and any other application role, the self-scoped
+     *       {@code _tide_*} E2EE roles) is benign.</li>
      * </ol>
      *
      * @param isClientRole       whether the role is a client role.
-     * @param roleName           the role's name (may be {@code null} → tainted).
+     * @param roleName           the role's name ({@code null} → fail-closed, NOT benign).
      * @param ownerClientId      the owning client's {@code clientId} for a client
      *                           role ({@code null} for a realm role).
      * @param defaultRolesName   the realm composite root name
-     *                           ({@code default-roles-<realm>}).
+     *                           ({@code default-roles-<realm>}). Retained for API
+     *                           stability; the root is benign because it is not a
+     *                           privileged role, so no special-casing is needed.
      */
     public static boolean isBenignChild(boolean isClientRole, String roleName,
                                         String ownerClientId, String defaultRolesName) {
         if (roleName == null) {
-            return false;
+            return false; // unresolvable name — fail closed
         }
-        if (!isClientRole) {
-            if (roleName.equals(defaultRolesName)) {
-                return true; // the composite root / a benign nested grouping
-            }
-            return IgaSystemEntityFilter.DEFAULT_REALM_ROLE_NAMES.contains(roleName);
+        return !isPrivilegedChild(isClientRole, roleName, ownerClientId);
+    }
+
+    /**
+     * True iff the role is on the realm-escalation surface (see class javadoc).
+     * The sole privilege boundary of the guard.
+     */
+    static boolean isPrivilegedChild(boolean isClientRole, String roleName, String ownerClientId) {
+        if (roleName == null) {
+            return true; // cannot classify → treat as privileged (fail-closed)
         }
-        // Client role: benign ONLY under the account surface, and only the
-        // stock baseline names. realm-management is never benign.
-        return ownerClientId != null
-                && BENIGN_ACCOUNT_CLIENT_IDS.contains(ownerClientId)
-                && BENIGN_ACCOUNT_ROLE_NAMES.contains(roleName);
+        // tide-realm-admin is privileged wherever it lives (defense-in-depth).
+        if (IgaApproverRoleRepointer.TIDE_REALM_ADMIN.equals(roleName)) {
+            return true;
+        }
+        if (isClientRole) {
+            // The ENTIRE realm-management client is the admin surface. Every other
+            // client's roles are application-scoped, not realm escalation.
+            return REALM_MANAGEMENT_CLIENT_ID.equals(ownerClientId);
+        }
+        // Realm role: privileged only if its bare name denotes realm administration.
+        return PRIVILEGED_REALM_ROLE_NAMES.contains(roleName);
     }
 
     /**
      * Walk the realm's {@code default-roles-<realm>} composite TRANSITIVELY
-     * (cycle-safe) and return true iff EVERY transitively-reachable role is
-     * benign per {@link #isBenignChild}. Fails closed (returns {@code false} +
-     * loud {@code ERROR}) on the first tainted child, naming it + the realm.
+     * (cycle-safe) and return true iff NO transitively-reachable role is privileged
+     * per {@link #isBenignChild}. Fails closed (returns {@code false} + loud
+     * {@code ERROR}) on the first privileged child, naming it + the realm.
      *
      * <p>A {@code null} realm or a realm with no default role is treated as
      * benign-vacuous (true): there is nothing privileged to confer. (The
@@ -178,12 +218,12 @@ public final class DefaultRoleCompositeGuard {
             String ownerClientId = clientIdOf(realm, role);
             if (!isBenignChild(role.isClientRole(), role.getName(), ownerClientId, defaultRolesName)) {
                 log.errorf("IGA MF2 GUARD: realm '%s' default-role composite "
-                        + "'%s' contains a NON-BENIGN child role '%s' (%s) — refusing to "
+                        + "'%s' contains a PRIVILEGED child role '%s' (%s) — refusing to "
                         + "treat self-registered users as accept-unattested eligible. A "
-                        + "privileged child on the default-role would confer privilege to "
-                        + "every unsigned self-registered user via composite expansion "
-                        + "(NOT a direct USER_ROLE_MAPPING row, so it is invisible to the "
-                        + "D1b user_role_mapping_set unit). Self-reg falls back to the "
+                        + "privileged child on the default-role would confer realm-escalation "
+                        + "privilege to every unsigned self-registered user via composite "
+                        + "expansion (NOT a direct USER_ROLE_MAPPING row, so it is invisible to "
+                        + "the D1b user_role_mapping_set unit). Self-reg falls back to the "
                         + "fail-closed / CR path. Remove the privileged child from the "
                         + "default-role to restore self-registration.",
                         realm.getName(), defaultRolesName, role.getName(),

--- a/iga-core/src/test/java/org/tidecloak/iga/services/DefaultRoleCompositeGuardTest.java
+++ b/iga-core/src/test/java/org/tidecloak/iga/services/DefaultRoleCompositeGuardTest.java
@@ -18,8 +18,12 @@ import org.keycloak.models.RoleModel;
 /**
  * ★ MF2 (HIGH) — the benign default-role composite guard. The whole
  * accept-unattested self-reg model trusts {@code default-roles-<realm>} confers
- * only benign baseline; this guard validates it by walking the composite
- * transitively and fail-closing on any privileged child.
+ * no realm-escalation privilege; this guard validates it by walking the
+ * composite transitively and fail-closing on any PRIVILEGED child
+ * (realm-management client roles + tide-realm-admin + bare admin realm-role
+ * names). NON-privileged application roles ({@code appUser}, the self-scoped
+ * {@code _tide_*} E2EE roles, custom app roles) are benign — they are exactly
+ * the default baseline every user is meant to hold.
  */
 class DefaultRoleCompositeGuardTest {
 
@@ -27,7 +31,7 @@ class DefaultRoleCompositeGuardTest {
     private static final String DEFAULT_ROLES = "default-roles-" + REALM;
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Pure leaf classifier
+    // Pure leaf classifier — BENIGN cases
     // ─────────────────────────────────────────────────────────────────────────
 
     @Test
@@ -49,24 +53,62 @@ class DefaultRoleCompositeGuardTest {
     }
 
     @Test
+    void leaf_applicationRealmRole_isBenign() {
+        // appUser — the operator's application baseline realm role. It is NOT a
+        // realm-escalation role, so it is benign. (Under the earlier allow-list this
+        // was WRONGLY tainted, which created ROLELESS self-registrants — the bug.)
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(false, "appUser", null, DEFAULT_ROLES));
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(false, "some-custom-role", null, DEFAULT_ROLES));
+    }
+
+    @Test
+    void leaf_tideSelfScopedE2EERoles_areBenign() {
+        // _tide_dob.selfencrypt / .selfdecrypt — self-scoped E2EE roles, modelled either
+        // as realm roles or as client roles under a non-realm-management client. Either
+        // shape is NON-privileged and therefore benign.
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(false, "_tide_dob.selfencrypt", null, DEFAULT_ROLES));
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(false, "_tide_dob.selfdecrypt", null, DEFAULT_ROLES));
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(true, "selfencrypt", "_tide_dob", DEFAULT_ROLES));
+    }
+
+    @Test
+    void leaf_customAppClientRole_isBenign() {
+        // A role under any client OTHER than realm-management is application-scoped, not
+        // realm escalation — benign under the denylist. Even a role NAMED like an admin
+        // action but owned by an application client is app-scoped, not realm control.
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(true, "do-stuff", "my-app", DEFAULT_ROLES));
+        assertTrue(DefaultRoleCompositeGuard.isBenignChild(true, "manage-account", "my-app", DEFAULT_ROLES));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Pure leaf classifier — PRIVILEGED (tainted) cases
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
     void leaf_realmManagementRoles_areTainted() {
+        // The ENTIRE realm-management client surface is privileged.
         assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "manage-users", "realm-management", DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "manage-realm", "realm-management", DEFAULT_ROLES));
         assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "realm-admin", "realm-management", DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "view-users", "realm-management", DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "impersonation", "realm-management", DEFAULT_ROLES));
+    }
+
+    @Test
+    void leaf_tideRealmAdmin_isTaintedByName_anyContainer() {
+        // tide-realm-admin is privileged wherever it lives (defense-in-depth): on
+        // realm-management (its real home), on any other client, or as a realm role.
         assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "tide-realm-admin", "realm-management", DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "tide-realm-admin", "some-other-client", DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(false, "tide-realm-admin", null, DEFAULT_ROLES));
     }
 
     @Test
-    void leaf_unknownRealmRole_isTainted() {
-        // Allow-list: an operator-authored realm role we cannot classify is NOT benign.
+    void leaf_privilegedRealmRoleNames_areTainted() {
+        // Bare realm-role names that denote realm administration (defense-in-depth).
         assertFalse(DefaultRoleCompositeGuard.isBenignChild(false, "admin", null, DEFAULT_ROLES));
-        assertFalse(DefaultRoleCompositeGuard.isBenignChild(false, "some-custom-role", null, DEFAULT_ROLES));
-    }
-
-    @Test
-    void leaf_accountNamedRoleUnderNonAccountClient_isTainted() {
-        // A role NAMED like an account baseline role but owned by another client is tainted.
-        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "manage-account", "my-app", DEFAULT_ROLES));
-        assertFalse(DefaultRoleCompositeGuard.isBenignChild(true, "view-profile", null, DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(false, "realm-admin", null, DEFAULT_ROLES));
+        assertFalse(DefaultRoleCompositeGuard.isBenignChild(false, "create-realm", null, DEFAULT_ROLES));
     }
 
     @Test
@@ -92,7 +134,7 @@ class DefaultRoleCompositeGuardTest {
     }
 
     @Test
-    void benignComposite_passes() {
+    void benignComposite_stockOnly_passes() {
         RealmModel realm = mock(RealmModel.class);
         when(realm.getName()).thenReturn(REALM);
 
@@ -111,6 +153,41 @@ class DefaultRoleCompositeGuardTest {
         assertTrue(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
                 "a default-role composite of only offline_access/uma + account baseline "
                         + "roles must be benign — accept-unattested self-reg stays eligible");
+    }
+
+    /**
+     * The exact staging default-role composite that the earlier allow-list wrongly
+     * refused — { appUser, manage-account, view-profile, offline_access,
+     * uma_authorization, _tide_dob.selfencrypt, _tide_dob.selfdecrypt } — must now be
+     * BENIGN so the Tide self-registrant receives default-roles at creation.
+     */
+    @Test
+    void reportedStagingDefaultComposite_isGrantable() {
+        RealmModel realm = mock(RealmModel.class);
+        when(realm.getName()).thenReturn(REALM);
+
+        ClientModel account = clientMock("account");
+        when(realm.getClientById("account-uuid")).thenReturn(account);
+        ClientModel tideDob = clientMock("_tide_dob");
+        when(realm.getClientById("tidedob-uuid")).thenReturn(tideDob);
+
+        RoleModel appUser = realmRole("appUser");
+        RoleModel manageAccount = clientRole("manage-account", "account-uuid");
+        RoleModel viewProfile = clientRole("view-profile", "account-uuid");
+        RoleModel offlineAccess = realmRole("offline_access");
+        RoleModel uma = realmRole("uma_authorization");
+        RoleModel selfEncrypt = clientRole("selfencrypt", "tidedob-uuid");
+        RoleModel selfDecrypt = clientRole("selfdecrypt", "tidedob-uuid");
+
+        RoleModel defaultRole = composite(DEFAULT_ROLES, false, null,
+                appUser, manageAccount, viewProfile, offlineAccess, uma, selfEncrypt, selfDecrypt);
+        when(realm.getDefaultRole()).thenReturn(defaultRole);
+
+        assertTrue(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
+                "the standard staging default-role composite (appUser + account baseline + "
+                        + "offline/uma + self-scoped _tide_* E2EE roles) contains NO "
+                        + "realm-escalation role, so it must be grantable to a Tide "
+                        + "self-registrant — the fix for the ROLELESS self-reg bug");
     }
 
     @Test
@@ -135,6 +212,34 @@ class DefaultRoleCompositeGuardTest {
                         + "to the D1b user_role_mapping_set unit)");
     }
 
+    /**
+     * The staging-shape composite but TAINTED with a realm-management child — proves the
+     * guard still refuses escalation even amid a legitimate benign baseline.
+     */
+    @Test
+    void taintedComposite_stagingShapePlusTideRealmAdmin_failsClosed() {
+        RealmModel realm = mock(RealmModel.class);
+        when(realm.getName()).thenReturn(REALM);
+
+        ClientModel account = clientMock("account");
+        when(realm.getClientById("account-uuid")).thenReturn(account);
+        ClientModel realmMgmt = clientMock("realm-management");
+        when(realm.getClientById("rm-uuid")).thenReturn(realmMgmt);
+
+        RoleModel appUser = realmRole("appUser");
+        RoleModel offlineAccess = realmRole("offline_access");
+        RoleModel manageAccount = clientRole("manage-account", "account-uuid");
+        RoleModel tideRealmAdmin = clientRole("tide-realm-admin", "rm-uuid"); // PRIVILEGED child
+
+        RoleModel defaultRole = composite(DEFAULT_ROLES, false, null,
+                appUser, offlineAccess, manageAccount, tideRealmAdmin);
+        when(realm.getDefaultRole()).thenReturn(defaultRole);
+
+        assertFalse(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
+                "a tide-realm-admin child on an otherwise-benign default-role composite must "
+                        + "still fail closed — the escalation vector stays shut");
+    }
+
     @Test
     void taintedComposite_nestedPrivilegedChild_failsClosedTransitively() {
         // default-roles → benign-grouping (realm role) → realm-management:realm-admin
@@ -145,30 +250,32 @@ class DefaultRoleCompositeGuardTest {
         when(realm.getClientById("rm-uuid")).thenReturn(realmMgmt);
 
         RoleModel realmAdmin = clientRole("realm-admin", "rm-uuid"); // PRIVILEGED leaf
-        // a nested realm role named like the default-roles root would be benign, but here
-        // the nested grouping is offline_access (benign) which itself composites the
-        // privileged leaf — proving the walk is transitive, not depth-1.
-        RoleModel nested = composite("offline_access", false, null, realmAdmin);
+        // a nested benignly-named grouping role that itself composites the privileged leaf —
+        // proving the walk is transitive, not depth-1.
+        RoleModel nested = composite("appUser", false, null, realmAdmin);
         RoleModel defaultRole = composite(DEFAULT_ROLES, false, null, nested);
         when(realm.getDefaultRole()).thenReturn(defaultRole);
 
         assertFalse(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
-                "a privileged role nested DEEP in the composite (not a direct child) must "
-                        + "still be caught — the walk is transitive");
+                "a privileged role nested DEEP in the composite (hidden under a benignly-named "
+                        + "grouping role) must still be caught — the walk is transitive");
     }
 
     @Test
-    void taintedComposite_unknownCustomRealmRole_failsClosed() {
+    void benignComposite_unknownCustomRealmRole_passes() {
+        // Policy flip vs the old allow-list: an unknown, NON-privileged operator-authored
+        // realm role is now BENIGN (it confers no realm escalation). This is what lets the
+        // operator's appUser / custom baseline roles ride the default composite.
         RealmModel realm = mock(RealmModel.class);
         when(realm.getName()).thenReturn(REALM);
 
-        RoleModel custom = realmRole("ops-superuser"); // not on the allowlist
+        RoleModel custom = realmRole("ops-report-viewer"); // non-privileged custom role
         RoleModel defaultRole = composite(DEFAULT_ROLES, false, null, custom);
         when(realm.getDefaultRole()).thenReturn(defaultRole);
 
-        assertFalse(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
-                "an unknown operator-authored realm role on the default-role composite is "
-                        + "tainted under the allow-list — we cannot positively classify it benign");
+        assertTrue(DefaultRoleCompositeGuard.isBenignDefaultRoleComposite(realm),
+                "an unknown NON-privileged operator realm role on the default composite is "
+                        + "benign under the denylist — only the realm-escalation surface is refused");
     }
 
     @Test


### PR DESCRIPTION
## Problem

Follow-up to #94. That fix removed the fragile stack-frame detection in `IgaUserProvider.shouldGrantDefaultRolesOnSelfCreate` (now `registrationAllowed && benignDefaultRoleComposite`), and it is confirmed deployed , but **Tide self-registered users still get zero realm roles**. Verified live on staging: a user self-registered via the Tide IdP broker (vuid-hash username) on a `registrationAllowed=true` realm has empty role mappings and no pending CR; invited/admin-created users on the same realm get their roles fine.

## Root cause (proven)

`DefaultRoleCompositeGuard.isBenignDefaultRoleComposite` was a strict **allowlist**: a composite child was benign only if it was `default-roles-{realm}`, `offline_access`/`uma_authorization`, or a stock `account` baseline role. The real staging default composite `{ appUser, manage-account, view-profile, offline_access, uma_authorization, _tide_dob.selfencrypt, _tide_dob.selfdecrypt }` contains members not on that allowlist (`appUser`, the self-scoped `_tide_*` E2EE roles) , none of them privileged. The transitive walk returned false at the first, tainting the whole composite → gate `true && false = false` → `super.addUser(..., grantDefaultRoles=false)` → roleless user, no CR. Ruled out (with code) the two alternatives: the seam IS hit, and the grant was never attempted so nothing was dropped.

## Fix

Invert the leaf classifier from an allowlist to a **privileged-role denylist**, keeping the cycle-safe transitive walk. A leaf is privileged iff: (a) any client role under the `realm-management` client, (b) named `tide-realm-admin` in any container, or (c) a realm role whose bare name is in `{admin, realm-admin, create-realm}`. Everything else (app roles, stock account roles, offline/uma, self-scoped `_tide_*.selfencrypt/.selfdecrypt`) is benign. Public signatures unchanged, so all three consumers (`IgaUserProvider`, `IgaUserAdapter.grantDefaultRolesForRegistration`, `IgaFirstAdminAutoCommit`) are fixed uniformly.

## Security rationale

The guard exists to stop a privileged role placed as a composite child of `default-roles-{realm}` from being conferred to every unsigned self-registrant (invisible to the D1b `user_role_mapping_set` unit, so it would attest clean). The genuine escalation surface is the `realm-management` client roles + Tide's `tide-realm-admin`; the denylist targets exactly those and stays fail-safe against hiding because the walk descends into every composite (a privileged leaf buried under a benign grouping role is still reached and refused). Application/account/E2EE-self roles confer no realm control and are the intended default baseline.

Residual tradeoff (flagged): a client role whose owning client cannot be resolved is treated as benign (the `tide-realm-admin` name check still catches the worst case); chosen over fail-closed-on-unresolved because that would re-break self-reg on a lookup flake , the exact bug being fixed. The producer `selfRegEligible` filter + U19 universal-inherit remain the actual TVE enforcement behind this guard.

## TVE-safety

Unchanged , the fix only widens which composites are *accepted*, not what is granted (still `realm.getDefaultRole()`). Realm default-role id stays the D1b exclusion; a default-roles-only user emits no `user_role_mapping_set` unit; ORK universal-inherits U19. Token gains the `account` audience, closure stays consistent.

## Tests

`DefaultRoleCompositeGuardTest` rewritten to the denylist policy , **19/19 pass**, including the exact staging composite as grantable and staging-shape+`tide-realm-admin` still refused. `IgaUserProviderRegistrationDefaultRolesTest` 6/6, `IgaFirstAdminAutoCommitTest` 19/19. `mvn -pl iga-core -am -DskipTests package` green.

## Deploy

Must reach `main` (staging resets `staging`←`main`). Ship via the official `deploy-stage.yml` (`reset_staging:true`) so the rebuilt image is known to be from post-merge `main`. Base branch was cut from the real deployed main tip `230e7a4f` (local `main` ref is stale), so it stacks cleanly on #94.