### PR TITLE
Port iga-core to Keycloak 26.7.0

### DIFF
--- a/iga-core/pom.xml
+++ b/iga-core/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <keycloak.version>26.5.5</keycloak.version>
+        <keycloak.version>26.7.0</keycloak.version>
     </properties>
 
     <dependencies>
@@ -99,12 +99,20 @@
         </dependency>
         <dependency>
             <!--
-              Provided by Keycloak 26.5.5 runtime
-              (com.fasterxml.jackson.dataformat.jackson-dataformat-cbor-2.19.2.jar
-              is on /opt/keycloak/lib/lib/main/). Keep at provided scope to avoid
+              Provided by the Keycloak runtime (jackson-dataformat-cbor is on
+              /opt/keycloak/lib/lib/main/). Keep at provided scope to avoid
               classloader conflicts and a duplicate class on the runtime path.
-              The 2.17.2 vs 2.19.2 mismatch is API-safe: we only use the public
-              CBORFactory no-arg constructor.
+
+              The pinned 2.17.2 is a COMPILE-ONLY floor and is deliberately not
+              kept in lockstep with the runtime jar. Keycloak does not pin
+              jackson in its root pom — the runtime version comes from the
+              Quarkus BOM, which moves 3.27.2 -> 3.33.2.1 in KC 26.7.0, so the
+              exact runtime jackson version is not statically resolvable from
+              source. The mismatch is API-safe: across iga-core we only touch
+              long-stable public Jackson 2.x API (ObjectMapper, JsonNode,
+              TypeReference, SerializationFeature, the CBORFactory no-arg
+              constructor, and the JsonInclude/JsonIgnoreProperties
+              annotations), all of which are unchanged throughout the 2.x line.
             -->
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
@@ -189,12 +197,15 @@
           instantiating it needs a RuntimeDelegate impl on the classpath. The
           ws.rs API is `provided` (Keycloak supplies RESTEasy at runtime); pull
           RESTEasy core at test scope so Response.status(...).build() resolves.
-          Version matches the RESTEasy shipped with Keycloak 26.5.5.
+          Version matches the RESTEasy shipped with Keycloak 26.7.0
+          (<resteasy.version> in the Keycloak 26.7.0 root pom; was 6.2.12.Final
+          on 26.5.5). Test-scope only — a drift here changes what the unit tests
+          run against, not the deployed runtime.
         -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-core</artifactId>
-            <version>6.2.12.Final</version>
+            <version>6.2.16.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaOrganizationProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaOrganizationProvider.java
@@ -136,6 +136,44 @@ import java.util.Map;
  * {@code IgaReplayDispatcher.replay(...)} — so replay rebuilds pass straight
  * through to {@code super} without re-interception, exactly like every other
  * Iga* provider.
+ *
+ * <h2>KC 26.7.0 organization-groups surface — NOT modelled by IGA</h2>
+ * Keycloak 26.7.0 adds seven methods to the {@code OrganizationProvider} SPI
+ * ({@code createGroup}, {@code getTopLevelGroups}, {@code searchGroupsByName},
+ * {@code searchGroupsByAttributes}, two {@code getOrganizationGroupsByMember}
+ * overloads and {@code getOrganizationGroup}), letting an admin create
+ * arbitrary nested groups INSIDE an organization. We inherit
+ * {@code InfinispanOrganizationProvider}'s implementations and deliberately do
+ * NOT override them. Consequences, established by reading the 26.7.0 source:
+ *
+ * <ul>
+ *   <li><b>Creation IS governed.</b>
+ *       {@code JpaOrganizationProvider.createGroup} binds
+ *       {@code groupProvider = session.groups()} and terminates in
+ *       {@code groupProvider.createGroup(realm, id, Type.ORGANIZATION, name,
+ *       parent)} — the 5-arg terminal that every {@code GroupProvider.createGroup}
+ *       default overload funnels into. {@code session.groups()} resolves to
+ *       {@link IgaRealmProvider} (GroupProviderFactory, order 2), whose
+ *       {@code createGroup} override intercepts it. So an org-group create still
+ *       raises a {@code CREATE_GROUP} change request. This path does NOT fail
+ *       open.</li>
+ *   <li><b>Attestation / ADOPT do NOT cover them.</b> Org-backed groups carry
+ *       {@code GroupModel.Type.ORGANIZATION} ({@code KEYCLOAK_GROUP.TYPE = 1}).
+ *       {@code IgaUnsignedRowScanner} filters {@code g.type = 0} and
+ *       {@code RealmAttestationExporter} skips {@code Type.ORGANIZATION} groups,
+ *       both by design — on 26.5.5 the only type-1 row was the single internal
+ *       org-backing group, which is not admin-authored. On 26.7.0 that
+ *       assumption no longer holds: admin-authored org groups are also type-1,
+ *       so they are governed on create but never enter the attested closure and
+ *       are never surfaced by the toggle-on ADOPT scan.</li>
+ * </ul>
+ *
+ * <p>Blast radius is limited to realms with the {@code ORGANIZATION} feature
+ * enabled ({@link IgaOrganizationProviderFactory#isSupported} delegates to KC's
+ * gate). Closing the asymmetry means teaching the scanner/exporter to
+ * distinguish the internal org-backing group from admin-authored org groups; it
+ * is intentionally out of scope for the 26.7.0 port and is left as a known gap
+ * rather than half-modelled. Do not assume org groups are attested.</p>
  */
 public class IgaOrganizationProvider extends InfinispanOrganizationProvider {
 

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmAdapter.java
@@ -453,20 +453,48 @@ public class IgaRealmAdapter extends RealmAdapter {
      * default-scope setup, where the realm's default-default / default-optional
      * scope templates are auto-created and must NOT be live-governed (they are
      * attested via the toggle-on ADOPT scan instead)? Matches if ANY of the
-     * bootstrap frames is present on the current stack (KC 26.5.5):
+     * bootstrap frames is present on the current stack.
+     *
+     * <p>Re-verified frame-by-frame against the upstream Keycloak 26.7.0 tag.
+     * The load-bearing frame is {@code DefaultClientScopes}: KC funnels EVERY
+     * protocol factory's default-scope creation through
+     * {@code DefaultClientScopes.createDefaultClientScopes}, which does
+     * {@code getProviderFactoriesStream(LoginProtocol.class).forEach(lpf ->
+     * lpf.createDefaultClientScopes(realm, ...))}. That frame therefore sits
+     * below OIDC/SAML/OID4VC alike and alone suffices; the per-factory frames
+     * below are defence in depth.</p>
+     *
      * <ul>
      *   <li>{@code OIDCLoginProtocolFactory.createDefaultClientScopesImpl} —
      *       profile/email/address/phone/roles/web-origins/microprofile-jwt/acr/
-     *       basic/organization.</li>
+     *       basic/organization, plus {@code delegation} as of 26.7.0. Extends
+     *       {@code AbstractLoginProtocolFactory}, hence the {@code ...Impl}
+     *       method name.</li>
      *   <li>{@code SamlProtocolFactory.createDefaultClientScopesImpl} —
-     *       role_list / saml_organization.</li>
-     *   <li>{@code OID4VCLoginProtocolFactory.createDefaultClientScopesImpl} —
-     *       oid4vc_natural_person.</li>
+     *       role_list / saml_organization, plus {@code AuthnContextClassRef} as
+     *       of 26.7.0. Also extends {@code AbstractLoginProtocolFactory}.</li>
+     *   <li>{@code OID4VCLoginProtocolFactory.createDefaultClientScopes} —
+     *       oid4vc_natural_person{_jwt,_sd}. NOTE: this factory implements
+     *       {@code LoginProtocolFactory} DIRECTLY (it does not extend
+     *       {@code AbstractLoginProtocolFactory}), so its method is
+     *       {@code createDefaultClientScopes} with NO {@code Impl} suffix.
+     *       This has been true since at least 26.5.5; the predicate previously
+     *       demanded {@code createDefaultClientScopesImpl} for this class,
+     *       which never matched, making the OID4VC arm dead code. Suppression
+     *       still worked via the {@code DefaultClientScopes} frame, so this is
+     *       a latent-hole fix, not a live-bug fix — but the arm is now correct
+     *       so it actually contributes its intended defence in depth.</li>
      *   <li>{@code DefaultClientScopes.createOfflineAccessClientScope} /
      *       {@code createDefaultClientScopes} — offline_access (server-spi-private
      *       {@code models.utils.DefaultClientScopes}).</li>
      *   <li>{@code RealmManager.createDefaultClientScopes} — the services-layer
-     *       entry point (covers any future factory).</li>
+     *       entry point (covers any future factory). It wraps the call in
+     *       {@code EntityManagers.runInBatch(session, () -> ...)}; the lambda
+     *       frame is {@code lambda$createDefaultClientScopes$N} and does NOT
+     *       match, but {@code runInBatch} executes synchronously so the real
+     *       {@code createDefaultClientScopes} frame remains on the stack below
+     *       it and DOES match. (This wrapper is present on 26.5.5 too — not a
+     *       26.7.0 regression.)</li>
      * </ul>
      * The governed admin route ({@code RealmAdminResource.addDefaultClientScope}
      * on an already-existing realm) carries NONE of these frames, so it is
@@ -479,9 +507,15 @@ public class IgaRealmAdapter extends RealmAdapter {
                     String cn = f.getDeclaringClass().getName();
                     String mn = f.getMethodName();
                     if (cn.startsWith("org.keycloak.protocol.oidc.OIDCLoginProtocolFactory")
-                            || cn.startsWith("org.keycloak.protocol.saml.SamlProtocolFactory")
-                            || cn.startsWith("org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory")) {
+                            || cn.startsWith("org.keycloak.protocol.saml.SamlProtocolFactory")) {
                         return "createDefaultClientScopesImpl".equals(mn);
+                    }
+                    // OID4VC implements LoginProtocolFactory directly -> no `Impl`
+                    // suffix. Accept both spellings so this arm keeps matching if
+                    // the factory is ever reparented onto AbstractLoginProtocolFactory.
+                    if (cn.startsWith("org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory")) {
+                        return "createDefaultClientScopes".equals(mn)
+                                || "createDefaultClientScopesImpl".equals(mn);
                     }
                     if ("org.keycloak.models.utils.DefaultClientScopes".equals(cn)) {
                         return true;

--- a/iga-core/src/main/java/org/tidecloak/iga/rest/IgaTveBundleResource.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/rest/IgaTveBundleResource.java
@@ -307,12 +307,38 @@ public class IgaTveBundleResource {
             }
 
             TokenManager tokenManager = new TokenManager();
-            // TokenManager.createClientAccessToken:
+            // TokenManager.createClientAccessToken (KC 26.7.0):
             //   public AccessToken createClientAccessToken(KeycloakSession, RealmModel, ClientModel,
-            //                                              UserModel, UserSessionModel, ClientSessionContext)
+            //                                              UserModel, UserSessionModel, ClientSessionContext,
+            //                                              boolean isOffline)
             // This is the claim-construction path (initToken + transformAccessToken) and does NOT
             // call session.tokens().encode(...), so the Tide-signed branch in DefaultTokenManager
             // is never reached.
+            //
+            // isOffline (NEW in 26.7.0; it replaced a `UriInfo uriInfo` parameter that
+            // initToken never actually read). We pass FALSE. This is a synthesized
+            // TVE claim-preview bundle, not an offline token: nothing is persisted, no
+            // refresh token is issued, and there is no offline user session.
+            //
+            // isOffline is threaded ONLY into
+            //   encoder.getTokenContextFromClientSessionContext(clientSessionCtx, rawId, isOffline)
+            // whose result is encoded into the token id (jti). It does NOT affect `exp` —
+            // initToken derives `offlineTokenRequested` independently, from whether the
+            // offline_access client scope is present in the ClientSessionContext.
+            //
+            // On THIS call site the flag is doubly inert, which is worth stating so nobody
+            // "fixes" it to true later:
+            //   1. DefaultTokenContextEncoderProvider checks the user session's persistence
+            //      state FIRST. Our userSession is created with SessionPersistenceState
+            //      .TRANSIENT (see above), so it takes the transient branch and the
+            //      isOffline argument is never read at all. With no CREATED_FROM_PERSISTENT
+            //      note on the session, the SessionType resolves to TRANSIENT.
+            //   2. Even that only shapes the encoded jti prefix, and we unconditionally
+            //      overwrite the jti with the engine-supported "trrtcc:" prefix a few lines
+            //      below.
+            // Passing true would therefore change nothing today, but it would be a lie about
+            // the call site's semantics and would start mattering the moment this path is
+            // given a persistent session.
 
             // Diagnostic — DEBUG log just before the mapper pipeline runs.
             // If mapperCount == 0 the cause is upstream (scope/user filtering
@@ -338,7 +364,8 @@ public class IgaTveBundleResource {
             }
 
             AccessToken claims = tokenManager.createClientAccessToken(
-                    session, realm, client, user, userSession, clientSessionCtx);
+                    session, realm, client, user, userSession, clientSessionCtx,
+                    /* isOffline = */ false);
 
             // Force engine-compatible jti prefix "trrtcc:" regardless of whether
             // the resolved TokenContextEncoder chose lightweight (encoded "lt")

--- a/iga-core/src/main/java/org/tidecloak/iga/services/IgaSystemEntityFilter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/services/IgaSystemEntityFilter.java
@@ -55,9 +55,19 @@ public final class IgaSystemEntityFilter {
 
     /**
      * KC's per-realm built-in clients. Mirrors
-     * {@code RepresentationToModel#getBuiltinClients} / the master-realm setup
-     * in stock KC 26.5.x — these clients are auto-created at realm creation
-     * and back the admin/account/CLI surfaces.
+     * {@code org.keycloak.models.Constants#defaultClients} / the master-realm
+     * setup in stock KC 26.7.x — these clients are auto-created at realm
+     * creation and back the admin/account/CLI surfaces.
+     *
+     * <p>Re-verified against the upstream 26.7.0 tag. {@code Constants
+     * .defaultClients} GREW in 26.7.0 (it was {account, admin-cli, broker,
+     * realm-management, security-admin-console}) and now additionally carries
+     * {@code account-console}, {@code admin-permissions}
+     * ({@code ADMIN_PERMISSIONS_CLIENT_ID}, the FGAPv2 admin-permissions
+     * client) and {@code _system}
+     * ({@code SystemClientUtil.SYSTEM_CLIENT_ID}). The latter two are new to
+     * this set — without them a 26.7.0 realm would surface them on toggle-on
+     * as admin-authored ADOPT_CLIENTs and quarantine them.</p>
      */
     public static final Set<String> BUILTIN_CLIENT_IDS = Set.of(
             "realm-management",
@@ -66,6 +76,15 @@ public final class IgaSystemEntityFilter {
             "security-admin-console",
             "broker",
             "admin-cli",
+            // KC 26.7.0: FGAPv2's admin-permissions client. Present as a
+            // Constants constant on 26.5.5 but only promoted into
+            // Constants.defaultClients in 26.7.0.
+            "admin-permissions",
+            // KC 26.7.0: SystemClientUtil.SYSTEM_CLIENT_ID. Lazily created
+            // (realm.addClient("_system")) for system operations when the
+            // `account` client is unavailable. Promoted into
+            // Constants.defaultClients in 26.7.0.
+            "_system",
             // Tide-realm default: the KC-hosted Tide admin console, auto-created
             // (create-if-absent) for every Tide-enabled realm by
             // VendorResource.setupTideAdminConsole (called from SignIdpSettings),
@@ -88,24 +107,41 @@ public final class IgaSystemEntityFilter {
      * soft-skipped (lifted by {@code iga.adopt.includeSystem=true}) so an
      * operator can still opt them in if needed.
      *
-     * <p>Sources (Keycloak 26.5.5):
+     * <p>Sources (re-verified against the upstream Keycloak 26.7.0 tag):
      * <ul>
      *   <li>{@code org.keycloak.protocol.oidc.OIDCLoginProtocolFactory
      *       #createDefaultClientScopesImpl}: profile, email, address, phone,
      *       roles, web-origins, microprofile-jwt, basic, service_account
      *       (always); acr (Profile.Feature.STEP_UP_AUTHENTICATION); organization
-     *       (Profile.Feature.ORGANIZATION).</li>
+     *       (Profile.Feature.ORGANIZATION); <b>delegation</b>
+     *       (Profile.Feature.TOKEN_EXCHANGE_DELEGATION) — NEW in 26.7.0.</li>
      *   <li>{@code org.keycloak.services.managers.RealmManager
      *       #setupOfflineTokens} → {@code DefaultClientScopes
      *       .createOfflineAccessClientScope}: offline_access.</li>
      *   <li>{@code org.keycloak.protocol.saml.SamlProtocolFactory
      *       #createDefaultClientScopesImpl}: role_list (always);
-     *       saml_organization (Profile.Feature.ORGANIZATION).</li>
+     *       saml_organization (Profile.Feature.ORGANIZATION);
+     *       <b>AuthnContextClassRef</b>
+     *       (Profile.Feature.STEP_UP_AUTHENTICATION_SAML, created by
+     *       {@code addSamlAuthnContextClassRefClientScope}) — NEW in
+     *       26.7.0.</li>
      *   <li>{@code org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory
-     *       #createDefaultClientScopesImpl}: oid4vc_natural_person
-     *       (when the OID4VC provider is enabled).</li>
+     *       #createDefaultClientScopes} (note: this factory implements
+     *       {@code LoginProtocolFactory} directly, so the method is
+     *       {@code createDefaultClientScopes}, NOT the
+     *       {@code ...Impl} variant used by the OIDC/SAML factories, which
+     *       extend {@code AbstractLoginProtocolFactory}): in 26.7.0 this loops
+     *       {@code VCFormat.SUPPORTED_FORMATS} and creates ONE scope per
+     *       format — {@code oid4vc_natural_person_jwt} (JWT_VC) and
+     *       {@code oid4vc_natural_person_sd} (SD_JWT_VC). On 26.5.5 it created
+     *       exactly one, {@code oid4vc_natural_person}.</li>
      * </ul>
      * </p>
+     *
+     * <p>{@code oid4vc_natural_person} (the 26.5.5 name) is RETAINED alongside
+     * the two 26.7.0 names: a realm provisioned on 26.5.5 and migrated forward
+     * still carries a row under the old name, and dropping it here would make
+     * the toggle-on ADOPT scan quarantine it as admin-authored.</p>
      *
      * <p>We list every name unconditionally (feature flags vary per
      * deployment); a missing scope just means the realm never had it and the
@@ -126,7 +162,17 @@ public final class IgaSystemEntityFilter {
             "organization",
             "role_list",
             "saml_organization",
-            "oid4vc_natural_person"
+            // KC 26.7.0: OIDC, gated on Profile.Feature.TOKEN_EXCHANGE_DELEGATION.
+            "delegation",
+            // KC 26.7.0: SAML, gated on Profile.Feature.STEP_UP_AUTHENTICATION_SAML.
+            "AuthnContextClassRef",
+            // OID4VC. 26.5.5 created a single "oid4vc_natural_person"; 26.7.0
+            // creates one scope per VCFormat.SUPPORTED_FORMATS instead. All
+            // three are listed so both fresh-26.7.0 and migrated-from-26.5.5
+            // realms are covered.
+            "oid4vc_natural_person",
+            "oid4vc_natural_person_jwt",
+            "oid4vc_natural_person_sd"
     );
 
     /**


### PR DESCRIPTION
Bumps `keycloak.version` to **26.7.0**. Adds the `isOffline` arg to `createClientAccessToken`; re-verified the StackWalker governance predicates + internal JPA subclass signatures against 26.7.0 (all still valid); updated IgaSystemEntityFilter's built-in client/default-scope lists for 26.7.0 (admin-permissions, _system, delegation, AuthnContextClassRef, split oid4vc scopes). No Liquibase collision with KC 26.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)