### PR TITLE
Suppress IGA capture during Keycloak model migration (fix 26.7.0 boot 409)

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientAdapter.java
@@ -11,6 +11,7 @@ import org.keycloak.models.jpa.entities.ClientEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.tidecloak.iga.services.IgaQuarantineCache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -149,6 +150,10 @@ public class IgaClientAdapter extends ClientAdapter {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientScopeAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaClientScopeAdapter.java
@@ -11,6 +11,7 @@ import org.keycloak.models.jpa.entities.ClientScopeEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.tidecloak.iga.services.IgaQuarantineCache;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -226,6 +227,10 @@ public class IgaClientScopeAdapter extends ClientScopeAdapter {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaGroupAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaGroupAdapter.java
@@ -2,6 +2,7 @@ package org.tidecloak.iga.providers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -208,6 +209,10 @@ public class IgaGroupAdapter extends GroupAdapter {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = session.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaOrganizationProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaOrganizationProvider.java
@@ -1,6 +1,7 @@
 package org.tidecloak.iga.providers;
 
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
@@ -207,6 +208,10 @@ public class IgaOrganizationProvider extends InfinispanOrganizationProvider {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmAdapter.java
@@ -2,6 +2,7 @@ package org.tidecloak.iga.providers;
 
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.GroupModel;
@@ -75,6 +76,10 @@ public class IgaRealmAdapter extends RealmAdapter {
         // (each of which gates on isIgaActive() before recording). Inert when the
         // flag is absent — ongoing admin edits stay governed.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmProvider.java
@@ -1,6 +1,7 @@
 package org.tidecloak.iga.providers;
 
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.GroupModel;
@@ -61,6 +62,10 @@ public class IgaRealmProvider extends JpaRealmProvider {
         // limited to the firstAdmin tide-claims passthrough). Inert when the flag is
         // absent — ongoing admin edits stay governed.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRoleAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRoleAdapter.java
@@ -2,6 +2,7 @@ package org.tidecloak.iga.providers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -195,6 +196,10 @@ public class IgaRoleAdapter extends RoleAdapter {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = session.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserAdapter.java
@@ -12,6 +12,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.tidecloak.iga.attestors.TideAttestor;
 import org.tidecloak.iga.replay.IgaReplayExtension;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.tidecloak.iga.services.IgaQuarantineCache;
 import org.tidecloak.iga.services.IgaUnsignedEntityService;
 import org.tidecloak.iga.services.TideRealmAdminGuard;
@@ -372,6 +373,10 @@ public class IgaUserAdapter extends UserAdapter {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaUserProvider.java
@@ -2,6 +2,7 @@ package org.tidecloak.iga.providers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.tidecloak.iga.services.IgaMigrationContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -89,6 +90,10 @@ public class IgaUserProvider extends JpaUserProvider {
         // Scoped vendor/system provisioning bypass (see
         // IgaChangeRequestService.IGA_VENDOR_PROVISIONING): apply directly, no capture.
         if (service.isVendorProvisioning()) return false;
+        // TIDECLOAK: Keycloak's own model migration must apply directly — never
+        // captured as a governance CR (would 409 on a realm with a pending CR
+        // and abort boot). See IgaMigrationContext.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath()) return false;
         Object replay = igaSession.getAttribute("IGA_REPLAY_ACTIVE");
         return !"true".equals(replay);
     }

--- a/iga-core/src/main/java/org/tidecloak/iga/services/IgaMigrationContext.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/services/IgaMigrationContext.java
@@ -1,0 +1,88 @@
+package org.tidecloak.iga.services;
+
+/**
+ * Detects whether the current thread is executing inside Keycloak's own
+ * model-version migration (the {@code MigrationModelManager} /
+ * {@code org.keycloak.migration.migrators.*} chain that runs on boot when the
+ * stored model version is older than the server's, and on realm-import version
+ * upgrades).
+ *
+ * <h2>Why this exists</h2>
+ * Keycloak's migrations write to realms/clients/client-scopes/roles through the
+ * normal model layer — {@code session.realms()}, {@code realm.getClientScopesStream()},
+ * {@code role.addCompositeRole(...)}, {@code session.clients().addClientScopeToAllClients(...)}
+ * etc. Those calls resolve to the IGA-wrapped providers/adapters (they win at
+ * factory {@code order() == 2}). Without a guard, an IGA-enabled realm that
+ * happens to carry a <em>pending</em> change request has every migration write
+ * captured by the IGA interceptor, and — because a foreign pending CR is a
+ * conflict — the capture path throws {@link org.tidecloak.iga.providers.IgaConflictException}.
+ *
+ * <p>At migration time there is no JAX-RS exception mapper, so that exception
+ * propagates uncaught out of the single {@code runJobInTransaction} that wraps
+ * both the migration and the stored-version bump. The transaction rolls back
+ * (version never advances) and the server fails to boot — and, because the
+ * version is not advanced, re-fails identically on every subsequent restart.
+ * This surfaced on the 26.7.0 upgrade, whose migration writes to every realm
+ * (new SAML {@code AuthnContextClassRef} scope, {@code admin-permissions}
+ * client, org admin roles, parameterized-scope attribute renames).</p>
+ *
+ * <h2>Semantics</h2>
+ * A Keycloak model migration is a mechanical, system-authored schema/config
+ * upgrade — <em>not</em> an admin-authored change for a governance approver to
+ * vote on. Its writes must apply directly to the model (fall through to
+ * {@code super.*}), exactly like replay ({@code IGA_REPLAY_ACTIVE}) and vendor
+ * provisioning ({@code IGA_VENDOR_PROVISIONING}). This helper is the third such
+ * "apply directly, never capture" signal; every {@code isIgaActive()} chokepoint
+ * consults it alongside the other two.
+ *
+ * <h2>Why a StackWalker (and not a session flag)</h2>
+ * The migration entry point lives in Keycloak core (the fork), so there is no
+ * iga-core-owned seam at which to set a session attribute around it. A
+ * thread-stack probe is self-contained in iga-core, needs no fork change, is
+ * immune to session-identity concerns, and matches the existing idiom already
+ * used in {@code IgaRealmAdapter.isOnRealmBootstrapPath()} /
+ * {@code IgaRealmProvider.isOnClientCreationPath()} /
+ * {@code IgaUserAdapter.computeImmediateCaller()}.
+ *
+ * <h2>No false positives on the normal request path</h2>
+ * The matched frames appear ONLY while a model-version migration is executing
+ * ({@code QuarkusJpaConnectionProviderFactory.migrateModel} at boot, or
+ * {@code MigrationModelManager.migrateImport} during a realm-rep import). A
+ * normal admin REST write (JAX-RS resource -> model provider) never traverses
+ * the {@code org.keycloak.migration.*} packages, so ongoing admin edits stay
+ * governed. The import-time migration case is correctly suppressed too — it is
+ * the same class of system-authored upgrade.
+ */
+public final class IgaMigrationContext {
+
+    /** Package prefix carrying every concrete migrator ({@code MigrateTo26_7_0},
+     *  {@code RealmMigration}, {@code MigrationUtils}, …). A migrator's own frame
+     *  ({@code migrateRealm} and its private helpers) is always on the stack
+     *  below any governed write it triggers, so matching the prefix ANYWHERE on
+     *  the stack catches writes that fan out through helper classes
+     *  (e.g. {@code AdminPermissionsSchema.init}, {@code addClientScopeToAllClients})
+     *  too. */
+    private static final String MIGRATORS_PACKAGE_PREFIX = "org.keycloak.migration.migrators.";
+
+    /** The migration transaction entry point — guaranteed present below every
+     *  migrator frame. Matched as belt-and-braces so the guard still holds if a
+     *  future migrator were to run a write without keeping its own frame on the
+     *  stack. */
+    private static final String MIGRATION_MODEL_MANAGER = "org.keycloak.migration.MigrationModelManager";
+
+    private IgaMigrationContext() {
+    }
+
+    /**
+     * @return {@code true} iff a Keycloak model-migration frame is present
+     *         anywhere on the current thread's call stack.
+     */
+    public static boolean isOnKeycloakMigrationPath() {
+        return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+                .walk(frames -> frames.anyMatch(f -> {
+                    String cn = f.getDeclaringClass().getName();
+                    return cn.startsWith(MIGRATORS_PACKAGE_PREFIX)
+                            || MIGRATION_MODEL_MANAGER.equals(cn);
+                }));
+    }
+}


### PR DESCRIPTION
## Problem
Keycloak 26.7.0's realm migration does direct governed model writes (rename dynamic-scope attrs, add SAML `AuthnContextClassRef` scope, add `admin-permissions` client, add org admin roles). These route through iga-core's wrapped model layer, which **captures them as change requests**. On a realm that already has a **pending CR**, the capture throws `IgaConflictException` (409). During migration there is no JAX-RS exception mapper, so it escapes and **aborts server boot** — and since migration + version-bump share one transaction, the rollback means the version never advances and **every restart re-fails**. Observed on `tidecloak-staging`.

## Fix
A migration is a mechanical system upgrade, not an admin-authored change — its writes must apply directly, never be captured/vetoed. New helper `IgaMigrationContext.isOnKeycloakMigrationPath()` (StackWalker matching `org.keycloak.migration.migrators.*` / `MigrationModelManager`, same idiom as the existing `isOnRealmBootstrapPath`), consulted in every `isIgaActive()` chokepoint (9 adapters/providers). On the migration stack, `isIgaActive()` returns false → the write falls through to `super.*` and applies directly (no capture, no 409). Boot proceeds, version bumps.

## Safety
- Normal admin REST writes are unaffected (never traverse `org.keycloak.migration.*` → no false positive); governance intact.
- Existing `IGA_REPLAY_ACTIVE` / `IGA_VENDOR_PROVISIONING` suppressions untouched (additive third signal).
- idp boot backfills run under PostMigrationEvent, off the migration stack — unaffected.
- **No data loss / no under-provisioning**: writes still apply, just not filed as CRs.

## QA-verify (post-deploy)
On IGA-ON attested realms the migration-written system entities carry no inline attestation and rely on the existing re-attestation/ADOPT path — confirm a post-upgrade re-attestation picks them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)