### PR TITLE
iga-core: boot-safe capture of 26.7.0 org-admin migration roles as pending CRs

### DIFF
--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaMigrationRoleCapture.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaMigrationRoleCapture.java
@@ -1,0 +1,322 @@
+package org.tidecloak.iga.providers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.jboss.logging.Logger;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.tidecloak.iga.services.IgaMigrationContext;
+import org.tidecloak.iga.entities.IgaChangeRequestEntity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Boot-safe migration-capture seam for governed role/composite creates that Keycloak's
+ * own model-version migration performs on an IGA-enabled realm.
+ *
+ * <h2>The problem</h2>
+ * Keycloak 26.7.0's {@code MigrateTo26_7_0.addOrganizationAdminRoles} adds three
+ * org-admin roles ({@code view-/manage-/query-organizations}) to admin clients on every
+ * realm, plus composite edges ({@code realm-admin ⊃ each}, {@code admin ⊃ each},
+ * {@code view ⊃ query}). Those writes resolve to the IGA-wrapped provider/adapter. If
+ * they are applied DIRECTLY during migration they land UNSIGNED (null {@code attestation}
+ * column); the login-time attestation closure then fails closed and nobody can log in.
+ * If they are captured through the ordinary REST seam they throw
+ * {@code IgaPendingApprovalException}/{@code IgaConflictException}, which is uncaught at
+ * boot and aborts startup.
+ *
+ * <h2>The design</h2>
+ * During migration, do NOT apply these governed creates. Capture each as a pending
+ * change request WITHOUT persisting the role/composite:
+ * <ul>
+ *   <li>{@code addRole} → a {@code CREATE_ROLE} CR + a {@link MigrationCaptureRoleModel}
+ *       phantom handle that persists no {@code RoleEntity} (invisible to the login
+ *       closure at first boot).</li>
+ *   <li>{@code existingRole.addCompositeRole(newRole)} → a dependent {@code ADD_COMPOSITE}
+ *       CR (via {@link #captureComposite}) keyed on the existing parent, depending on the
+ *       child's {@code CREATE_ROLE} CR so commit ordering is enforced.</li>
+ *   <li>The migrator's null-guarded {@code view ⊃ query} edge is skipped by core (its
+ *       {@code getRole} re-query returns null for the phantom); {@link #captureClientRole}
+ *       re-creates it as a dependent {@code ADD_COMPOSITE} CR.</li>
+ * </ul>
+ * An admin later approves+commits the CR set through the normal multiAdmin ceremony;
+ * {@code IgaReplayDispatcher.replayCreateRole} stamps {@code RoleEntity.attestation} and
+ * the composite edges — proper VVK signature, no new crypto.
+ *
+ * <h2>Invariants</h2>
+ * All CRs are written on a SEPARATE {@code runJobInTransaction} session so the inner tx
+ * commits independently while the outer migration tx (and its stored-version bump) run to
+ * completion. Nothing here throws and nothing calls {@code setRollbackOnly()} — the
+ * migration MUST finish. Idempotency/dedup via {@code findMigrationCreateRoleCr}
+ * (by role name + owning client, so a re-run with freshly-generated ids does not pile up
+ * duplicates) and {@code findDuplicatePending} for the composite edges.
+ */
+public final class IgaMigrationRoleCapture {
+
+    private static final Logger log = Logger.getLogger(IgaMigrationRoleCapture.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Author stamped on migration-authored CRs. Not an admin identity; it carries no
+     *  authorization and never satisfies a commit quorum — the CR still needs the realm's
+     *  ordinary multiAdmin approvals before {@code IgaReplayDispatcher} applies it. */
+    private static final String REQUESTED_BY = "system";
+
+    // 26.7.0 addOrganizationAdminRoles / addQueryCompositeRoles role names.
+    private static final String VIEW_ORGANIZATIONS_ROLE = "view-organizations";
+    private static final String QUERY_ORGANIZATIONS_ROLE = "query-organizations";
+
+    private final KeycloakSession session;
+
+    public IgaMigrationRoleCapture(KeycloakSession session) {
+        this.session = session;
+    }
+
+    /**
+     * True iff a governed role/composite create should be captured (rather than applied)
+     * right now: we are on Keycloak's model-migration call path AND IGA is enabled for the
+     * realm. When IGA is off, migration writes apply directly (there is nothing to sign).
+     */
+    public static boolean isActive(KeycloakSession session, RealmModel realm) {
+        if (realm == null) {
+            return false;
+        }
+        if (!IgaMigrationContext.isOnKeycloakMigrationPath()) {
+            return false;
+        }
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+        return new IgaChangeRequestService(em, session).isIgaEnabled(realm);
+    }
+
+    // -------------------------------------------------------------------------
+    // SITE 1 — role create (IgaRealmProvider.addRealmRole / addClientRole)
+    // -------------------------------------------------------------------------
+
+    /** Capture a REALM role create (defensive — no known 26.7.0 realm-role migration write,
+     *  but any future migrator that adds a realm role on an IGA-on realm is covered). */
+    public RoleModel captureRealmRole(RealmModel realm, String id, String name) {
+        String roleId = (id != null) ? id : KeycloakModelUtils.generateId();
+        MigrationCaptureRoleModel phantom = new MigrationCaptureRoleModel(
+                this, realm, realm, roleId, name, /*clientRole=*/false,
+                /*containerId=*/realm.getId(), /*clientUuid=*/null, /*clientId=*/null);
+        writeCreateRoleCrIfAbsent(realm, phantom);
+        return phantom;
+    }
+
+    /** Capture a CLIENT role create (the 26.7.0 org-admin roles land here). */
+    public RoleModel captureClientRole(RealmModel realm, ClientModel client, String id, String name) {
+        String roleId = (id != null) ? id : KeycloakModelUtils.generateId();
+        MigrationCaptureRoleModel phantom = new MigrationCaptureRoleModel(
+                this, realm, client, roleId, name, /*clientRole=*/true,
+                /*containerId=*/client.getId(), /*clientUuid=*/client.getId(),
+                /*clientId=*/client.getClientId());
+        writeCreateRoleCrIfAbsent(realm, phantom);
+
+        // Core's addQueryCompositeRoles wires view-organizations ⊃ query-organizations,
+        // but it re-queries both via ClientModel.getRole(...), which returns null for our
+        // not-yet-committed phantoms, so core skips it. query-organizations is created
+        // AFTER view-organizations in the migrator, so by the time we capture query the
+        // view CR already exists — re-create the edge as a dependent ADD_COMPOSITE CR.
+        if (QUERY_ORGANIZATIONS_ROLE.equals(name)) {
+            synthesizeViewQueryComposite(realm, client.getId(), roleId);
+        }
+        return phantom;
+    }
+
+    /**
+     * Fold a phantom's later {@code setDescription}/{@code setAttribute} mutations back into
+     * its pending {@code CREATE_ROLE} CR so the captured representation matches what vanilla
+     * Keycloak would have persisted. No-op if the CR was deduped away (a prior pending CR for
+     * the same role name already exists).
+     */
+    void onRoleUpdated(MigrationCaptureRoleModel phantom) {
+        RealmModel realm = phantom.realm();
+        String roleId = phantom.getId();
+        runInSideTransaction(realm, (newRealm, service) -> {
+            IgaChangeRequestEntity cr = service.findPending(newRealm.getId(), "ROLE", roleId);
+            if (cr != null && "CREATE_ROLE".equals(cr.getActionType())) {
+                service.updateRows(cr.getId(), List.of(buildCreateRoleRow(phantom)));
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // SITE 2 — composite add on an EXISTING role (IgaRoleAdapter.addCompositeRole)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Capture {@code parent.addCompositeRole(child)} performed by the migrator on an EXISTING
+     * (committed) parent role — e.g. {@code realm-admin}/{@code admin} gaining a new org-admin
+     * role. Recorded as an {@code ADD_COMPOSITE} CR (role name/id as DATA, never an FK) that
+     * depends on the child's {@code CREATE_ROLE} CR so the child exists before the edge is
+     * replayed. Never persists a {@code CompositeRoleEntity} (the phantom child has no
+     * {@code RoleEntity}; a direct persist would FK-fail at the outer flush).
+     */
+    public void captureComposite(RealmModel realm, RoleModel parent, RoleModel child) {
+        if (parent == null || child == null) {
+            return;
+        }
+        String parentId = parent.getId();
+        String childId = child.getId();
+        if (parentId == null || childId == null) {
+            return;
+        }
+        runInSideTransaction(realm, (newRealm, service) -> {
+            List<Map<String, Object>> rows = List.of(compositeRow(parentId, childId));
+            if (service.findDuplicatePending(newRealm.getId(), "ROLE", parentId, "ADD_COMPOSITE", rows) != null) {
+                log.debugf("IGA migration-capture ADD_COMPOSITE already pending: parent=%s child=%s — skip",
+                        parentId, childId);
+                return;
+            }
+            List<String> dependsOn = null;
+            IgaChangeRequestEntity childCreate = service.findPending(newRealm.getId(), "ROLE", childId);
+            if (childCreate != null && "CREATE_ROLE".equals(childCreate.getActionType())) {
+                dependsOn = List.of(childCreate.getId());
+            }
+            service.create(newRealm, "ROLE", parentId, "ADD_COMPOSITE", rows, REQUESTED_BY, dependsOn);
+            log.infof("IGA migration-capture: ADD_COMPOSITE parent=%s child=%s (dependsOn=%s)",
+                    parentId, childId, dependsOn);
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    private void writeCreateRoleCrIfAbsent(RealmModel realm, MigrationCaptureRoleModel phantom) {
+        runInSideTransaction(realm, (newRealm, service) -> {
+            IgaChangeRequestEntity existing = findMigrationCreateRoleCr(
+                    service, newRealm.getId(), phantom.clientUuid(), phantom.getName());
+            if (existing != null) {
+                log.debugf("IGA migration-capture CREATE_ROLE already pending for name=%s "
+                        + "(client=%s) — skip (idempotent)", phantom.getName(), phantom.clientUuid());
+                return;
+            }
+            service.create(newRealm, "ROLE", phantom.getId(), "CREATE_ROLE",
+                    List.of(buildCreateRoleRow(phantom)), REQUESTED_BY);
+            log.infof("IGA migration-capture: CREATE_ROLE name=%s (uuid=%s, clientRole=%s, client=%s) "
+                    + "— captured as pending CR, no RoleEntity persisted",
+                    phantom.getName(), phantom.getId(), phantom.clientRole(), phantom.clientId());
+        });
+    }
+
+    private void synthesizeViewQueryComposite(RealmModel realm, String clientUuid, String queryRoleId) {
+        runInSideTransaction(realm, (newRealm, service) -> {
+            IgaChangeRequestEntity viewCreate = findMigrationCreateRoleCr(
+                    service, newRealm.getId(), clientUuid, VIEW_ORGANIZATIONS_ROLE);
+            if (viewCreate == null) {
+                return; // view-organizations not captured on this client — nothing to wire
+            }
+            String viewRoleId = viewCreate.getEntityId();
+            List<Map<String, Object>> rows = List.of(compositeRow(viewRoleId, queryRoleId));
+            if (service.findDuplicatePending(newRealm.getId(), "ROLE", viewRoleId, "ADD_COMPOSITE", rows) != null) {
+                return;
+            }
+            List<String> dependsOn = new ArrayList<>();
+            dependsOn.add(viewCreate.getId());
+            IgaChangeRequestEntity queryCreate = service.findPending(newRealm.getId(), "ROLE", queryRoleId);
+            if (queryCreate != null && "CREATE_ROLE".equals(queryCreate.getActionType())) {
+                dependsOn.add(queryCreate.getId());
+            }
+            service.create(newRealm, "ROLE", viewRoleId, "ADD_COMPOSITE", rows, REQUESTED_BY, dependsOn);
+            log.infof("IGA migration-capture: ADD_COMPOSITE view-organizations(%s) ⊃ query-organizations(%s) "
+                    + "(dependsOn=%s)", viewRoleId, queryRoleId, dependsOn);
+        });
+    }
+
+    /**
+     * Find a pending {@code CREATE_ROLE} CR by role NAME + owning client UUID (not by the
+     * freshly-generated role id), so a migration re-run — which allocates new ids — resolves
+     * the already-captured CR instead of piling up a duplicate.
+     */
+    private IgaChangeRequestEntity findMigrationCreateRoleCr(IgaChangeRequestService service,
+                                                             String realmId, String clientUuid,
+                                                             String roleName) {
+        for (IgaChangeRequestEntity cr : service.findPendingByAction(realmId, "ROLE", "CREATE_ROLE")) {
+            for (Map<String, Object> row : service.parseRows(cr.getRowsJson())) {
+                if (roleName.equals(row.get("NAME"))
+                        && java.util.Objects.equals(clientUuid, row.get("CLIENT_UUID"))) {
+                    return cr;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Map<String, Object> buildCreateRoleRow(MigrationCaptureRoleModel phantom) {
+        RoleRepresentation rep = new RoleRepresentation();
+        rep.setId(phantom.getId());
+        rep.setName(phantom.getName());
+        rep.setDescription(phantom.description());
+        rep.setClientRole(phantom.clientRole());
+        rep.setContainerId(phantom.getContainerId());
+        if (!phantom.attributesView().isEmpty()) {
+            Map<String, List<String>> attrs = new LinkedHashMap<>();
+            phantom.attributesView().forEach((k, v) -> attrs.put(k, new ArrayList<>(v)));
+            rep.setAttributes(attrs);
+        }
+        // NOTE: no composites folded here. The only phantom-parent edge in this migration
+        // (view ⊃ query) is emitted as its own dependent ADD_COMPOSITE CR (see
+        // synthesizeViewQueryComposite), keeping replay uniform with the existing
+        // IgaReplayDispatcher.replayCreateRole / addCompositeDirect contract.
+        String repJson;
+        try {
+            repJson = MAPPER.writeValueAsString(rep);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new RuntimeException("IGA migration-capture: failed to serialize RoleRepresentation "
+                    + "for role=" + phantom.getName(), e);
+        }
+
+        // Row contract must match IgaReplayDispatcher.rebuildCreateRoleFromRow / resolveClient:
+        // ID, NAME, REALM_ID, CLIENT_ROLE, and for client roles CLIENT_UUID/CLIENT_ID/
+        // CLIENT_REALM_CONSTRAINT, plus REP_JSON.
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("ID", phantom.getId());
+        row.put("NAME", phantom.getName());
+        row.put("REALM_ID", phantom.realm().getId());
+        row.put("CLIENT_ROLE", phantom.clientRole());
+        if (phantom.clientRole()) {
+            if (phantom.clientUuid() != null) row.put("CLIENT_UUID", phantom.clientUuid());
+            if (phantom.clientId() != null) row.put("CLIENT_ID", phantom.clientId());
+            row.put("CLIENT_REALM_CONSTRAINT", phantom.realm().getId());
+        }
+        row.put("REP_JSON", repJson);
+        return row;
+    }
+
+    private static Map<String, Object> compositeRow(String parentId, String childId) {
+        // Row contract must match IgaReplayDispatcher.addCompositeDirect (resolves both by id).
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("COMPOSITE", parentId);
+        row.put("CHILD_ROLE", childId);
+        return row;
+    }
+
+    @FunctionalInterface
+    private interface CaptureJob {
+        void run(RealmModel realm, IgaChangeRequestService service);
+    }
+
+    /**
+     * Run a CR write on a SEPARATE Keycloak session/transaction so it commits independently
+     * of the outer migration transaction (whose stored-version bump must still commit).
+     */
+    private void runInSideTransaction(RealmModel realm, CaptureJob job) {
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), newSession -> {
+            RealmModel newRealm = newSession.realms().getRealm(realm.getId());
+            if (newRealm == null) {
+                return;
+            }
+            EntityManager newEm = newSession.getProvider(JpaConnectionProvider.class).getEntityManager();
+            IgaChangeRequestService service = new IgaChangeRequestService(newEm, newSession);
+            job.run(newRealm, service);
+        });
+    }
+}

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmProvider.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRealmProvider.java
@@ -299,6 +299,14 @@ public class IgaRealmProvider extends JpaRealmProvider {
 
     @Override
     public RoleModel addRealmRole(RealmModel realm, String id, String name) {
+        // TIDECLOAK: Keycloak's own model migration on an IGA-on realm must NOT apply
+        // this create directly (it would land un-attested and fail the login closure)
+        // nor throw through the REST capture seam (uncaught at boot). Capture it as a
+        // pending CREATE_ROLE CR and return a non-persisting phantom handle. See
+        // IgaMigrationRoleCapture.
+        if (IgaMigrationRoleCapture.isActive(igaSession, realm)) {
+            return new IgaMigrationRoleCapture(igaSession).captureRealmRole(realm, id, name);
+        }
         // partialImport batch governance for REALM ROLE. Same gap
         // class as createGroup: under POST /partialImport, KC's
         // RolesPartialImport.doImport → RepresentationToModel.importRoles →
@@ -384,6 +392,11 @@ public class IgaRealmProvider extends JpaRealmProvider {
     @Override
     public RoleModel addClientRole(ClientModel client, String id, String name) {
         RealmModel realm = client.getRealm();
+        // TIDECLOAK: migration-capture (see addRealmRole / IgaMigrationRoleCapture). The
+        // 26.7.0 org-admin roles (view-/manage-/query-organizations) are created here.
+        if (IgaMigrationRoleCapture.isActive(igaSession, realm)) {
+            return new IgaMigrationRoleCapture(igaSession).captureClientRole(realm, client, id, name);
+        }
         // partialImport batch governance for CLIENT ROLE. Same gap
         // class as addRealmRole: under POST /partialImport, KC's
         // RolesPartialImport.doImport → RepresentationToModel.importRoles
@@ -447,6 +460,40 @@ public class IgaRealmProvider extends JpaRealmProvider {
         RoleEntity entity = em.find(RoleEntity.class, id);
         if (entity == null) return base;
         return new IgaRoleAdapter(igaSession, realm, em, entity);
+    }
+
+    // -------------------------------------------------------------------------
+    // Role-by-NAME lookups — normally left to JpaRealmProvider (returning a plain
+    // RoleAdapter). During a Keycloak model migration ONLY, wrap the result in an
+    // IgaRoleAdapter so a composite-add the migrator performs on an EXISTING role
+    // (MigrationUtils.addAdminRole: realm.getRole("admin")/client.getRole("realm-admin")
+    // .addCompositeRole(newOrgRole)) is intercepted at IgaRoleAdapter.addCompositeRole
+    // and captured as an ADD_COMPOSITE CR — instead of a plain RoleAdapter persisting a
+    // CompositeRoleEntity that references the not-yet-committed phantom child (FK-fail at
+    // the outer flush) UNSIGNED. The StackWalker gate keeps ordinary runtime lookups
+    // (token issuance, admin edits) on the unwrapped fast path. Phantom (not-yet-committed)
+    // roles are never wrapped here: super.get*Role queries the DB and returns null for
+    // them, so core's null-guarded addQueryCompositeRoles still skips cleanly.
+    // -------------------------------------------------------------------------
+
+    @Override
+    public RoleModel getRealmRole(RealmModel realm, String name) {
+        RoleModel base = super.getRealmRole(realm, name);
+        if (base != null && IgaMigrationContext.isOnKeycloakMigrationPath()) {
+            RoleEntity entity = em.find(RoleEntity.class, base.getId());
+            if (entity != null) return new IgaRoleAdapter(igaSession, realm, em, entity);
+        }
+        return base;
+    }
+
+    @Override
+    public RoleModel getClientRole(ClientModel client, String name) {
+        RoleModel base = super.getClientRole(client, name);
+        if (base != null && IgaMigrationContext.isOnKeycloakMigrationPath()) {
+            RoleEntity entity = em.find(RoleEntity.class, base.getId());
+            if (entity != null) return new IgaRoleAdapter(igaSession, client.getRealm(), em, entity);
+        }
+        return base;
     }
 
     // -------------------------------------------------------------------------

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRoleAdapter.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/IgaRoleAdapter.java
@@ -428,6 +428,16 @@ public class IgaRoleAdapter extends RoleAdapter {
             super.addCompositeRole(role);
             return;
         }
+        // TIDECLOAK: Keycloak's own model migration adding a composite to an EXISTING
+        // role (e.g. realm-admin/admin ⊃ a new org-admin role). The child is a
+        // not-yet-committed migration-capture phantom, so super.addCompositeRole would
+        // FK-fail at the outer flush, and applying the edge directly would leave an
+        // un-attested CompositeRoleEntity that fails the login closure. Capture it as a
+        // dependent ADD_COMPOSITE CR instead. See IgaMigrationRoleCapture.
+        if (IgaMigrationContext.isOnKeycloakMigrationPath() && getService().isIgaEnabled(realm)) {
+            new IgaMigrationRoleCapture(session).captureComposite(realm, this, role);
+            return;
+        }
         if (!isIgaActive()) {
             super.addCompositeRole(role);
             return;

--- a/iga-core/src/main/java/org/tidecloak/iga/providers/MigrationCaptureRoleModel.java
+++ b/iga-core/src/main/java/org/tidecloak/iga/providers/MigrationCaptureRoleModel.java
@@ -1,0 +1,183 @@
+package org.tidecloak.iga.providers;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleContainerModel;
+import org.keycloak.models.RoleModel;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * In-memory, NON-persisting {@link RoleModel} handle returned to Keycloak's own
+ * model-version migration when a governed role create is intercepted on an
+ * IGA-enabled realm (see {@link IgaMigrationRoleCapture}).
+ *
+ * <h2>Why this is not a {@code RoleAdapter}</h2>
+ * The migration-capture design requires that the create be recorded as a pending
+ * {@code CREATE_ROLE} change request while NO {@code RoleEntity} is written to the
+ * database — a role that exists only as a pending CR is invisible to the login
+ * attestation closure (which walks the live committed model), so first-boot login
+ * still works; an admin later approves the CR through the normal multiAdmin
+ * ceremony which stamps the attestation. A real {@code RoleAdapter} is backed by a
+ * {@code RoleEntity}; even a transient one risks being flushed into the outer
+ * migration transaction's persistence context ({@code RealmMigration.migrate} runs
+ * {@code EntityManagers.flush(session, true)} once per realm), which would turn the
+ * phantom into a real, un-attested row. This class holds NO entity at all, so there
+ * is nothing the outer EM can ever persist.
+ *
+ * <h2>What the migrator does with this handle</h2>
+ * {@code MigrationUtils.addAdminRole} calls {@code client.addRole(name)} (→ here),
+ * then {@code role.setDescription(...)}, then hands the role to
+ * {@code existingAdminRole.addCompositeRole(role)} (captured separately at the
+ * {@link IgaRoleAdapter#addCompositeRole} seam). {@code setDescription} /
+ * {@code setAttribute} mutations are folded back into the pending CR's REP_JSON via
+ * {@link IgaMigrationRoleCapture#onRoleUpdated} so the captured representation matches
+ * what vanilla Keycloak would have persisted. Composite-add ON this phantom is a
+ * no-op: the only such edge in the 26.7.0 migrator (view ⊃ query) is re-queried by
+ * {@code ClientModel.getRole(...)}, which returns null for a phantom, so the migrator
+ * skips it and {@link IgaMigrationRoleCapture} re-creates that edge as a dependent
+ * {@code ADD_COMPOSITE} CR instead.
+ */
+final class MigrationCaptureRoleModel implements RoleModel {
+
+    private final IgaMigrationRoleCapture capture;
+    private final RealmModel realm;
+    private final RoleContainerModel container;
+    private final String id;
+    private final boolean clientRole;
+    private final String containerId;
+    private final String clientUuid;
+    private final String clientId;
+
+    private String name;
+    private String description;
+    private final Map<String, List<String>> attributes = new LinkedHashMap<>();
+
+    MigrationCaptureRoleModel(IgaMigrationRoleCapture capture, RealmModel realm,
+                              RoleContainerModel container, String id, String name,
+                              boolean clientRole, String containerId,
+                              String clientUuid, String clientId) {
+        this.capture = capture;
+        this.realm = realm;
+        this.container = container;
+        this.id = id;
+        this.name = name;
+        this.clientRole = clientRole;
+        this.containerId = containerId;
+        this.clientUuid = clientUuid;
+        this.clientId = clientId;
+    }
+
+    RealmModel realm() { return realm; }
+    boolean clientRole() { return clientRole; }
+    String clientUuid() { return clientUuid; }
+    String clientId() { return clientId; }
+    String description() { return description; }
+    Map<String, List<String>> attributesView() { return attributes; }
+
+    @Override
+    public String getId() { return id; }
+
+    @Override
+    public String getName() { return name; }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+        capture.onRoleUpdated(this);
+    }
+
+    @Override
+    public String getDescription() { return description; }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+        capture.onRoleUpdated(this);
+    }
+
+    @Override
+    public boolean isComposite() { return false; }
+
+    @Override
+    public void addCompositeRole(RoleModel role) {
+        // No-op by design. Core never reaches this on a phantom: the sole
+        // phantom-parent edge in the 26.7.0 migrator (view ⊃ query) is guarded by
+        // a ClientModel.getRole(...) re-query that returns null for phantoms, so
+        // the migrator skips it; IgaMigrationRoleCapture re-creates it as a
+        // dependent ADD_COMPOSITE CR. Persisting anything here would defeat the
+        // "no committed row during migration" invariant.
+    }
+
+    @Override
+    public void removeCompositeRole(RoleModel role) {
+        // No-op — see addCompositeRole.
+    }
+
+    @Override
+    public Stream<RoleModel> getCompositesStream() { return Stream.empty(); }
+
+    @Override
+    public Stream<RoleModel> getCompositesStream(String search, Integer first, Integer max) {
+        return Stream.empty();
+    }
+
+    @Override
+    public boolean isClientRole() { return clientRole; }
+
+    @Override
+    public String getContainerId() { return containerId; }
+
+    @Override
+    public RoleContainerModel getContainer() { return container; }
+
+    @Override
+    public boolean hasRole(RoleModel role) { return this.equals(role); }
+
+    @Override
+    public void setSingleAttribute(String name, String value) {
+        List<String> values = new ArrayList<>();
+        values.add(value);
+        attributes.put(name, values);
+        capture.onRoleUpdated(this);
+    }
+
+    @Override
+    public void setAttribute(String name, List<String> values) {
+        attributes.put(name, values == null ? new ArrayList<>() : new ArrayList<>(values));
+        capture.onRoleUpdated(this);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+        capture.onRoleUpdated(this);
+    }
+
+    @Override
+    public String getFirstAttribute(String name) {
+        List<String> values = attributes.get(name);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        List<String> values = attributes.get(name);
+        return values == null ? Stream.empty() : values.stream();
+    }
+
+    @Override
+    public Map<String, List<String>> getAttributes() {
+        return new LinkedHashMap<>(attributes);
+    }
+
+    // Container may be a ClientModel (client role) or a RealmModel (realm role).
+    @SuppressWarnings("unused")
+    ClientModel containerAsClient() {
+        return (container instanceof ClientModel c) ? c : null;
+    }
+}


### PR DESCRIPTION
## Problem

Porting the Tide fork 26.5.5 → 26.7.0. On an **in-place upgrade of an IGA-on realm**, Keycloak 26.7.0's `MigrateTo26_7_0.addOrganizationAdminRoles` adds three org-admin roles (`view-`/`manage-`/`query-organizations`) to admin clients on every realm, plus composite edges (`realm-admin`/`admin ⊃ each`, `view ⊃ query`). These writes resolve to the IGA-wrapped provider/adapter.

- The **original** failure: capture threw `IgaConflictException`/`IgaPendingApprovalException`, uncaught at boot → startup abort, and because the migration + version-bump share one tx, the version never advanced → re-fail every restart.
- **Fix A** (PR #100, `IgaMigrationContext.isOnKeycloakMigrationPath`) made these writes **apply directly** during migration to dodge the 409 — but "directly" means **UNSIGNED**: the new roles get a NULL `attestation` column, so the login-time attestation closure **fails closed** and no one can log in. Most staging realms are multiAdmin, which correctly has no self-sign path.

## Design (validated)

During migration, do **not** apply these governed creates. Capture each as a **pending change request without persisting** the role/composite. A role that exists only as a pending CR is invisible to the login closure (which walks the live committed model), so first-boot login works. An admin later approves+commits the CR set through the **normal multiAdmin ceremony** — `IgaReplayDispatcher.replayCreateRole` stamps `RoleEntity.attestation`, the composite edges are stamped on commit → proper VVK signature, org-admin capability lights up. **No new crypto; the admin threshold is respected.**

## What changed (iga-core only, +562 / −0)

- **`IgaMigrationRoleCapture`** (new) — writes `CREATE_ROLE` / `ADD_COMPOSITE` CRs on a **separate `runJobInTransaction`** (payload as DATA, not FK), dedupes, never throws, never `setRollbackOnly`.
- **`MigrationCaptureRoleModel`** (new) — a non-persisting in-memory `RoleModel` phantom (holds **no** `RoleEntity`, so nothing can be flushed into the outer migration EM).
- **`IgaRealmProvider.addRealmRole`/`addClientRole`** — route into the capture seam on the migration path.
- **`IgaRealmProvider.getRealmRole`/`getClientRole`** — wrap the result in `IgaRoleAdapter` **only** on the migration path, so a composite-add on the existing `realm-admin`/`admin` role (obtained via `getRole`, otherwise a plain `RoleAdapter`) reaches the interception seam. Runtime lookups stay on the unwrapped fast path; phantom roles are never wrapped (DB lookup returns null), so core's null-guarded `addQueryCompositeRoles` skips and `view ⊃ query` is re-created as its own dependent `ADD_COMPOSITE` CR.
- **`IgaRoleAdapter.addCompositeRole`** — migration branch capturing the edge as a dependent `ADD_COMPOSITE` CR (`dependsOn` the child's `CREATE_ROLE`, so commit ordering is enforced) instead of persisting an un-attested / FK-invalid `CompositeRoleEntity`.

This **supersedes the migration half of Fix A** (PR #100). The `IgaMigrationContext` detector Fix A introduced is retained and now feeds the capture seam instead of a direct apply. **PR #100 should likely be closed in favor of this one** (its detector is included here).

## Operational consequence

After the upgrade, the org-admin roles arrive as **pending change requests**, not live roles. An admin must drive the normal multiAdmin quorum to approve+commit them before org-admin functions are available. This is the intended governance behavior — the capability is deferred, not lost, and nothing is applied unsigned.

## Scope notes (from the U2 closure analysis)

- **SAML #8** (`migrateSamlAuthnContextClassRefClientScope`, gated on `STEP_UP_AUTHENTICATION_SAML`) writes `CLIENT_SCOPE` / `CLIENT_SCOPE_CLIENT` rows, which **are** in the signed closure — it needs the same capture treatment **if that feature is enabled**. Flagged as a **feature-gated follow-up**, not part of this PR.
- **FGAPv2 #3** (`updateAdminPermissionsSchema`) authz scopes/resources carry **no** attestation column → safe to apply directly.

## Testing / review status

- Compiles clean (`mvn -o -pl iga-core -am compile`). No stack run.
- **A `tide-crypto-redteam` review of the capture seam is pending** before merge, then user testing. **Do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)